### PR TITLE
Add frontend build check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI
 
 on:
   push:
@@ -19,3 +19,16 @@ jobs:
       - run: bun install
 
       - run: bun run ci
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install
+
+      - run: bun run --filter frontend build


### PR DESCRIPTION
## Summary
- Add frontend build check to CI workflow
- Rename lint.yml to ci.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)