### PR TITLE
Add Claude Code configuration and documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if jq -r '.tool_input.command // \"\"' | grep -q \"git commit\"; then bun run ci || { echo '{\"decision\":\"block\",\"reason\":\"CI check failed. Fix errors before committing.\"}'; exit 2; }; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+sahai is an AI Coding Agent orchestration tool that manages Claude Code and Codex agents through a web-based Kanban interface. Each task runs in an isolated Git worktree with real-time log streaming via SSE.
+
+## Commands
+
+```bash
+# Install dependencies
+bun install
+
+# Development (runs both backend and frontend)
+bun run dev
+
+# Run individually
+bun run dev:backend   # Hono server on port 3001
+bun run dev:frontend  # Vite dev server on port 3000
+
+# Linting and formatting (Biome)
+bun run lint          # Lint check
+bun run format        # Format files
+bun run check         # Lint + format with auto-fix
+bun run ci            # CI check (run before commits)
+
+# Database (from backend/)
+bun run db:generate   # Generate migration from schema changes
+bun run db:migrate    # Apply migrations
+bun run db:studio     # Open Drizzle Studio
+
+# Frontend build
+bun run --filter frontend build
+```
+
+## Architecture
+
+### Monorepo Structure (Bun Workspaces)
+
+- **backend/**: Hono + SQLite (drizzle-orm) API server
+- **frontend/**: React + Vite + Jotai
+- **shared/**: Shared TypeScript types


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with pre-commit hook that runs `bun run ci` before commits
- Add `CLAUDE.md` with project overview, development commands, and architecture overview

## Test plan
- [ ] Verify CI passes
- [ ] Verify pre-commit hook blocks commits when lint fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)