### PR TITLE
Implement ProjectRepository association API

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { runMigrations } from "./db/client";
+import projectRepositories from "./routes/project-repositories";
 import projects from "./routes/projects";
 import repositories from "./routes/repositories";
 
@@ -16,6 +17,7 @@ app.get("/v1/health", (c) => {
 });
 
 app.route("/v1/projects", projects);
+app.route("/v1/projects", projectRepositories);
 app.route("/v1/repositories", repositories);
 
 export default {

--- a/backend/src/routes/__tests__/project-repositories.test.ts
+++ b/backend/src/routes/__tests__/project-repositories.test.ts
@@ -1,0 +1,201 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { unlinkSync } from "node:fs";
+import { resolve } from "node:path";
+import { db, runMigrations } from "../../db/client";
+import { projectRepositories, projects, repositories } from "../../db/schema";
+import app from "../project-repositories";
+
+const TEST_DB_PATH = resolve(import.meta.dirname, "../../../data/test.db");
+
+beforeAll(() => {
+  process.env.DB_PATH = TEST_DB_PATH;
+  runMigrations();
+});
+
+beforeEach(async () => {
+  await db.delete(projectRepositories);
+  await db.delete(projects);
+  await db.delete(repositories);
+});
+
+afterAll(() => {
+  try {
+    unlinkSync(TEST_DB_PATH);
+  } catch {
+    // ignore if file doesn't exist
+  }
+});
+
+async function createProject(id: string, name: string) {
+  const now = new Date().toISOString();
+  await db.insert(projects).values({
+    id,
+    name,
+    description: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+async function createRepository(id: string, name: string, path: string) {
+  const now = new Date().toISOString();
+  await db.insert(repositories).values({
+    id,
+    name,
+    path,
+    defaultBranch: "main",
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+describe("GET /:projectId/repositories", () => {
+  test("returns empty array when no associations exist", async () => {
+    await createProject("project-1", "Project 1");
+
+    const res = await app.request("/project-1/repositories");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  test("returns associated repositories", async () => {
+    await createProject("project-1", "Project 1");
+    await createRepository("repo-1", "Repo 1", "/path/to/repo1");
+    await createRepository("repo-2", "Repo 2", "/path/to/repo2");
+
+    const now = new Date().toISOString();
+    await db.insert(projectRepositories).values({
+      projectId: "project-1",
+      repositoryId: "repo-1",
+      createdAt: now,
+    });
+    await db.insert(projectRepositories).values({
+      projectId: "project-1",
+      repositoryId: "repo-2",
+      createdAt: now,
+    });
+
+    const res = await app.request("/project-1/repositories");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveLength(2);
+    expect(data[0].name).toBe("Repo 1");
+    expect(data[1].name).toBe("Repo 2");
+  });
+
+  test("returns 404 for non-existent project", async () => {
+    const res = await app.request("/non-existent/repositories");
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe("Project not found");
+  });
+});
+
+describe("POST /:projectId/repositories/:repositoryId", () => {
+  test("creates association between project and repository", async () => {
+    await createProject("project-1", "Project 1");
+    await createRepository("repo-1", "Repo 1", "/path/to/repo1");
+
+    const res = await app.request("/project-1/repositories/repo-1", {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.projectId).toBe("project-1");
+    expect(data.repositoryId).toBe("repo-1");
+    expect(data.createdAt).toBeDefined();
+  });
+
+  test("returns 404 for non-existent project", async () => {
+    await createRepository("repo-1", "Repo 1", "/path/to/repo1");
+
+    const res = await app.request("/non-existent/repositories/repo-1", {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe("Project not found");
+  });
+
+  test("returns 404 for non-existent repository", async () => {
+    await createProject("project-1", "Project 1");
+
+    const res = await app.request("/project-1/repositories/non-existent", {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe("Repository not found");
+  });
+
+  test("returns 409 for duplicate association", async () => {
+    await createProject("project-1", "Project 1");
+    await createRepository("repo-1", "Repo 1", "/path/to/repo1");
+
+    const now = new Date().toISOString();
+    await db.insert(projectRepositories).values({
+      projectId: "project-1",
+      repositoryId: "repo-1",
+      createdAt: now,
+    });
+
+    const res = await app.request("/project-1/repositories/repo-1", {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error).toBe("Association already exists");
+  });
+});
+
+describe("DELETE /:projectId/repositories/:repositoryId", () => {
+  test("deletes association", async () => {
+    await createProject("project-1", "Project 1");
+    await createRepository("repo-1", "Repo 1", "/path/to/repo1");
+
+    const now = new Date().toISOString();
+    await db.insert(projectRepositories).values({
+      projectId: "project-1",
+      repositoryId: "repo-1",
+      createdAt: now,
+    });
+
+    const res = await app.request("/project-1/repositories/repo-1", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.message).toBe("Association deleted");
+
+    // Verify it's deleted
+    const getRes = await app.request("/project-1/repositories");
+    expect(getRes.status).toBe(200);
+    const repos = await getRes.json();
+    expect(repos).toHaveLength(0);
+  });
+
+  test("returns 404 for non-existent association", async () => {
+    await createProject("project-1", "Project 1");
+    await createRepository("repo-1", "Repo 1", "/path/to/repo1");
+
+    const res = await app.request("/project-1/repositories/repo-1", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe("Association not found");
+  });
+});

--- a/backend/src/routes/project-repositories.ts
+++ b/backend/src/routes/project-repositories.ts
@@ -1,0 +1,125 @@
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { db } from "../db/client";
+import { projectRepositories, projects, repositories } from "../db/schema";
+
+const app = new Hono();
+
+// GET /v1/projects/:projectId/repositories - List repositories for a project
+app.get("/:projectId/repositories", async (c) => {
+  const projectId = c.req.param("projectId");
+
+  // Check if project exists
+  const project = await db
+    .select()
+    .from(projects)
+    .where(eq(projects.id, projectId));
+
+  if (project.length === 0) {
+    return c.json({ error: "Project not found" }, 404);
+  }
+
+  // Get associated repositories
+  const result = await db
+    .select({
+      id: repositories.id,
+      name: repositories.name,
+      path: repositories.path,
+      defaultBranch: repositories.defaultBranch,
+      createdAt: repositories.createdAt,
+      updatedAt: repositories.updatedAt,
+    })
+    .from(projectRepositories)
+    .innerJoin(
+      repositories,
+      eq(projectRepositories.repositoryId, repositories.id),
+    )
+    .where(eq(projectRepositories.projectId, projectId));
+
+  return c.json(result);
+});
+
+// POST /v1/projects/:projectId/repositories/:repositoryId - Associate repository with project
+app.post("/:projectId/repositories/:repositoryId", async (c) => {
+  const projectId = c.req.param("projectId");
+  const repositoryId = c.req.param("repositoryId");
+
+  // Check if project exists
+  const project = await db
+    .select()
+    .from(projects)
+    .where(eq(projects.id, projectId));
+
+  if (project.length === 0) {
+    return c.json({ error: "Project not found" }, 404);
+  }
+
+  // Check if repository exists
+  const repository = await db
+    .select()
+    .from(repositories)
+    .where(eq(repositories.id, repositoryId));
+
+  if (repository.length === 0) {
+    return c.json({ error: "Repository not found" }, 404);
+  }
+
+  // Check if association already exists
+  const existing = await db
+    .select()
+    .from(projectRepositories)
+    .where(
+      and(
+        eq(projectRepositories.projectId, projectId),
+        eq(projectRepositories.repositoryId, repositoryId),
+      ),
+    );
+
+  if (existing.length > 0) {
+    return c.json({ error: "Association already exists" }, 409);
+  }
+
+  const now = new Date().toISOString();
+  const newAssociation = {
+    projectId,
+    repositoryId,
+    createdAt: now,
+  };
+
+  await db.insert(projectRepositories).values(newAssociation);
+  return c.json(newAssociation, 201);
+});
+
+// DELETE /v1/projects/:projectId/repositories/:repositoryId - Remove association
+app.delete("/:projectId/repositories/:repositoryId", async (c) => {
+  const projectId = c.req.param("projectId");
+  const repositoryId = c.req.param("repositoryId");
+
+  // Check if association exists
+  const existing = await db
+    .select()
+    .from(projectRepositories)
+    .where(
+      and(
+        eq(projectRepositories.projectId, projectId),
+        eq(projectRepositories.repositoryId, repositoryId),
+      ),
+    );
+
+  if (existing.length === 0) {
+    return c.json({ error: "Association not found" }, 404);
+  }
+
+  await db
+    .delete(projectRepositories)
+    .where(
+      and(
+        eq(projectRepositories.projectId, projectId),
+        eq(projectRepositories.repositoryId, repositoryId),
+      ),
+    );
+
+  return c.json({ message: "Association deleted" });
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- Add `backend/src/routes/project-repositories.ts` with endpoints:
  - `GET /v1/projects/:projectId/repositories` - List repositories for a project
  - `POST /v1/projects/:projectId/repositories/:repositoryId` - Associate repository with project
  - `DELETE /v1/projects/:projectId/repositories/:repositoryId` - Remove association
- Returns 404 if project or repository doesn't exist
- Returns 409 if association already exists (on POST)
- Add comprehensive tests (9 tests) for all endpoints

Closes #7

## Test plan
- [x] All 31 tests pass (11 projects + 11 repositories + 9 project-repositories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)