### PR TITLE
Implement Repository detail page with Kanban board

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-router-dom": "^7.9.6",
+    "shared": "workspace:*",
     "swr": "^2.3.7"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Layout } from "./components";
-import { Home, ProjectDetail, ProjectList } from "./pages";
+import { Home, ProjectDetail, ProjectList, RepositoryDetail } from "./pages";
 
 export function App() {
   return (
@@ -22,6 +22,14 @@ export function App() {
             element={
               <Suspense fallback={<div>Loading...</div>}>
                 <ProjectDetail />
+              </Suspense>
+            }
+          />
+          <Route
+            path="repositories/:repositoryId"
+            element={
+              <Suspense fallback={<div>Loading...</div>}>
+                <RepositoryDetail />
               </Suspense>
             }
           />

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,1 +1,2 @@
 export * from "./projects";
+export * from "./repositories";

--- a/frontend/src/api/repositories.ts
+++ b/frontend/src/api/repositories.ts
@@ -1,0 +1,62 @@
+import type { Task } from "shared/types";
+import { apiPost } from "./client";
+
+export interface RepositoryResponse {
+  id: string;
+  name: string;
+  path: string;
+  defaultBranch: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TaskResponse {
+  id: string;
+  repositoryId: string;
+  title: string;
+  description: string | null;
+  status: string;
+  executor: string;
+  branchName: string;
+  baseBranch: string;
+  worktreePath: string | null;
+  createdAt: string;
+  updatedAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+function toTask(response: TaskResponse): Task {
+  return {
+    ...response,
+    description: response.description ?? undefined,
+    status: response.status as Task["status"],
+    executor: response.executor as Task["executor"],
+    worktreePath: response.worktreePath ?? undefined,
+    createdAt: new Date(response.createdAt),
+    updatedAt: new Date(response.updatedAt),
+    startedAt: response.startedAt ? new Date(response.startedAt) : undefined,
+    completedAt: response.completedAt
+      ? new Date(response.completedAt)
+      : undefined,
+  };
+}
+
+export interface CreateTaskInput {
+  title: string;
+  description?: string;
+  executor: string;
+  branchName: string;
+  baseBranch?: string;
+}
+
+export async function createTask(
+  repositoryId: string,
+  input: CreateTaskInput,
+): Promise<Task> {
+  const data = await apiPost<TaskResponse>(
+    `/repositories/${repositoryId}/tasks`,
+    input,
+  );
+  return toTask(data);
+}

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -1,0 +1,48 @@
+import type { Task } from "shared/types";
+import { Status } from "shared/types";
+import { TaskCard } from "./TaskCard";
+
+interface KanbanBoardProps {
+  tasks: Task[];
+}
+
+const COLUMNS: { status: Task["status"]; label: string }[] = [
+  { status: Status.TODO, label: "TODO" },
+  { status: Status.InProgress, label: "In Progress" },
+  { status: Status.InReview, label: "In Review" },
+  { status: Status.Done, label: "Done" },
+];
+
+export function KanbanBoard({ tasks }: KanbanBoardProps) {
+  const tasksByStatus = (status: Task["status"]) =>
+    tasks.filter((task) => task.status === status);
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(4, 1fr)",
+        gap: "16px",
+      }}
+    >
+      {COLUMNS.map((column) => (
+        <div
+          key={column.status}
+          style={{
+            backgroundColor: "#f5f5f5",
+            borderRadius: "4px",
+            padding: "8px",
+            minHeight: "200px",
+          }}
+        >
+          <h4 style={{ margin: "0 0 12px 0", textAlign: "center" }}>
+            {column.label}
+          </h4>
+          {tasksByStatus(column.status).map((task) => (
+            <TaskCard key={task.id} task={task} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -1,0 +1,32 @@
+import type { Task } from "shared/types";
+
+interface TaskCardProps {
+  task: Task;
+}
+
+export function TaskCard({ task }: TaskCardProps) {
+  return (
+    <div
+      style={{
+        border: "1px solid #ccc",
+        borderRadius: "4px",
+        padding: "8px",
+        marginBottom: "8px",
+        backgroundColor: "#fff",
+      }}
+    >
+      <div style={{ fontWeight: "bold", marginBottom: "4px" }}>
+        {task.title}
+      </div>
+      {task.description && (
+        <div style={{ fontSize: "12px", color: "#666", marginBottom: "4px" }}>
+          {task.description}
+        </div>
+      )}
+      <div style={{ fontSize: "11px", color: "#888" }}>
+        <span>{task.executor}</span>
+        <span style={{ marginLeft: "8px" }}>{task.branchName}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,1 +1,3 @@
+export * from "./KanbanBoard";
 export * from "./Layout";
+export * from "./TaskCard";

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./useProjects";
+export * from "./useRepositories";

--- a/frontend/src/hooks/useRepositories.ts
+++ b/frontend/src/hooks/useRepositories.ts
@@ -1,0 +1,47 @@
+import type { Repository, Task } from "shared/types";
+import useSWR from "swr";
+import { fetcher } from "../api/client";
+import type { RepositoryResponse, TaskResponse } from "../api/repositories";
+
+function toRepository(response: RepositoryResponse): Repository {
+  return {
+    ...response,
+    createdAt: new Date(response.createdAt),
+    updatedAt: new Date(response.updatedAt),
+  };
+}
+
+function toTask(response: TaskResponse): Task {
+  return {
+    ...response,
+    description: response.description ?? undefined,
+    status: response.status as Task["status"],
+    executor: response.executor as Task["executor"],
+    worktreePath: response.worktreePath ?? undefined,
+    createdAt: new Date(response.createdAt),
+    updatedAt: new Date(response.updatedAt),
+    startedAt: response.startedAt ? new Date(response.startedAt) : undefined,
+    completedAt: response.completedAt
+      ? new Date(response.completedAt)
+      : undefined,
+  };
+}
+
+export function useRepository(id: string) {
+  const { data } = useSWR<RepositoryResponse>(`/repositories/${id}`, fetcher, {
+    suspense: true,
+  });
+  return data ? toRepository(data) : null;
+}
+
+export function useRepositoryTasks(repositoryId: string) {
+  const { data, mutate } = useSWR<TaskResponse[]>(
+    `/repositories/${repositoryId}/tasks`,
+    fetcher,
+    { suspense: true },
+  );
+  return {
+    tasks: data?.map(toTask) ?? [],
+    mutate,
+  };
+}

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -41,7 +41,9 @@ function ProjectDetailContent({ projectId }: { projectId: string }) {
           <ul>
             {repositories.map((repo) => (
               <li key={repo.id}>
-                <strong>{repo.name}</strong>
+                <Link to={`/repositories/${repo.id}`}>
+                  <strong>{repo.name}</strong>
+                </Link>
                 <br />
                 <small>
                   Path: {repo.path} | Branch: {repo.defaultBranch}

--- a/frontend/src/pages/RepositoryDetail.tsx
+++ b/frontend/src/pages/RepositoryDetail.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { Executor } from "shared/types";
+import { createTask } from "../api";
+import { KanbanBoard } from "../components";
+import { useRepository, useRepositoryTasks } from "../hooks";
+
+export function RepositoryDetail() {
+  const { repositoryId } = useParams<{ repositoryId: string }>();
+
+  if (!repositoryId) {
+    return <div>Repository ID is required</div>;
+  }
+
+  return <RepositoryDetailContent repositoryId={repositoryId} />;
+}
+
+function RepositoryDetailContent({ repositoryId }: { repositoryId: string }) {
+  const repository = useRepository(repositoryId);
+  const { tasks, mutate } = useRepositoryTasks(repositoryId);
+  const [showForm, setShowForm] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [executor, setExecutor] = useState<string>(Executor.ClaudeCode);
+  const [branchName, setBranchName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!repository) {
+    return <div>Repository not found</div>;
+  }
+
+  const handleCreateTask = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !branchName.trim()) return;
+
+    try {
+      setCreating(true);
+      setError(null);
+      await createTask(repositoryId, {
+        title: title.trim(),
+        description: description.trim() || undefined,
+        executor,
+        branchName: branchName.trim(),
+      });
+      setTitle("");
+      setDescription("");
+      setBranchName("");
+      setShowForm(false);
+      mutate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create task");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div>
+      <Link to="/projects">&larr; Back to Projects</Link>
+
+      <h2>{repository.name}</h2>
+      <p>
+        <small>
+          Path: {repository.path} | Default Branch: {repository.defaultBranch}
+        </small>
+      </p>
+
+      <section style={{ marginBottom: "24px" }}>
+        {!showForm ? (
+          <button type="button" onClick={() => setShowForm(true)}>
+            + New Task
+          </button>
+        ) : (
+          <div
+            style={{
+              border: "1px solid #ccc",
+              borderRadius: "4px",
+              padding: "16px",
+              maxWidth: "400px",
+            }}
+          >
+            <h3 style={{ margin: "0 0 12px 0" }}>Create New Task</h3>
+            {error && <p style={{ color: "red" }}>{error}</p>}
+            <form onSubmit={handleCreateTask}>
+              <div style={{ marginBottom: "8px" }}>
+                <label htmlFor="task-title">Title:</label>
+                <br />
+                <input
+                  id="task-title"
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  required
+                  style={{ width: "100%" }}
+                />
+              </div>
+              <div style={{ marginBottom: "8px" }}>
+                <label htmlFor="task-description">Description:</label>
+                <br />
+                <textarea
+                  id="task-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  style={{ width: "100%" }}
+                  rows={3}
+                />
+              </div>
+              <div style={{ marginBottom: "8px" }}>
+                <label htmlFor="task-executor">Executor:</label>
+                <br />
+                <select
+                  id="task-executor"
+                  value={executor}
+                  onChange={(e) => setExecutor(e.target.value)}
+                >
+                  <option value={Executor.ClaudeCode}>Claude Code</option>
+                  <option value={Executor.Codex}>Codex</option>
+                </select>
+              </div>
+              <div style={{ marginBottom: "8px" }}>
+                <label htmlFor="task-branch">Branch Name:</label>
+                <br />
+                <input
+                  id="task-branch"
+                  type="text"
+                  value={branchName}
+                  onChange={(e) => setBranchName(e.target.value)}
+                  required
+                  style={{ width: "100%" }}
+                />
+              </div>
+              <div style={{ display: "flex", gap: "8px" }}>
+                <button type="submit" disabled={creating}>
+                  {creating ? "Creating..." : "Create"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowForm(false)}
+                  disabled={creating}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          </div>
+        )}
+      </section>
+
+      <KanbanBoard tasks={tasks} />
+    </div>
+  );
+}

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,3 +1,4 @@
 export * from "./Home";
 export * from "./ProjectDetail";
 export * from "./ProjectList";
+export * from "./RepositoryDetail";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
@@ -5,5 +6,10 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+  },
+  resolve: {
+    alias: {
+      shared: resolve(__dirname, "../shared"),
+    },
   },
 });


### PR DESCRIPTION
## Summary
- Add API functions and SWR hooks for repositories and tasks
- Create TaskCard component for displaying task information (title, description, executor, branch)
- Create KanbanBoard component with 4 columns (TODO, InProgress, InReview, Done)
- Implement RepositoryDetail page with Kanban board and task creation form
- Add route for `/repositories/:repositoryId`
- Add links from ProjectDetail to repository pages
- Configure vite alias for shared package resolution

Closes #11

## Test plan
- [x] Run `bun run check` to verify linting passes
- [x] Run `bun run --filter frontend build` to verify build succeeds
- [ ] Manual testing: verify Kanban board displays tasks in correct columns
- [ ] Manual testing: verify task creation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)