### PR TITLE
Add task status update support to PUT endpoint

### DIFF
--- a/packages/backend/src/routes/__tests__/tasks.test.ts
+++ b/packages/backend/src/routes/__tests__/tasks.test.ts
@@ -222,6 +222,38 @@ describe("PUT /:id", () => {
 
     expect(res.status).toBe(404);
   });
+
+  test("updates task status", async () => {
+    await createRepository("repo-1", "Repo 1");
+    await createTask("task-1", "repo-1", "Task 1");
+
+    const res = await taskById.request("/task-1", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "InProgress" }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("InProgress");
+    expect(data.startedAt).toBeDefined();
+  });
+
+  test("sets completedAt when status changes to Done", async () => {
+    await createRepository("repo-1", "Repo 1");
+    await createTask("task-1", "repo-1", "Task 1", "InReview");
+
+    const res = await taskById.request("/task-1", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "Done" }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("Done");
+    expect(data.completedAt).toBeDefined();
+  });
 });
 
 describe("DELETE /:id", () => {

--- a/packages/backend/src/routes/tasks.ts
+++ b/packages/backend/src/routes/tasks.ts
@@ -93,11 +93,22 @@ taskById.put("/:id", async (c) => {
     return c.json({ error: "Task not found" }, 404);
   }
 
-  const updated = {
+  const updated: Record<string, unknown> = {
     title: body.title ?? existing[0].title,
     description: body.description ?? existing[0].description,
+    status: body.status ?? existing[0].status,
     updatedAt: now,
   };
+
+  // Set startedAt when transitioning to InProgress
+  if (body.status === "InProgress" && !existing[0].startedAt) {
+    updated.startedAt = now;
+  }
+
+  // Set completedAt when transitioning to Done
+  if (body.status === "Done" && !existing[0].completedAt) {
+    updated.completedAt = now;
+  }
 
   await db.update(tasks).set(updated).where(eq(tasks.id, id));
 


### PR DESCRIPTION
## Summary
- Extend `PUT /v1/tasks/:id` to support `status` field updates
- Auto-set `startedAt` timestamp when transitioning to `InProgress`
- Auto-set `completedAt` timestamp when transitioning to `Done`
- Add 2 new tests for status update functionality

This fixes the implementation gap in Issue #8 where the PUT endpoint only updated title and description but not status.

## Test plan
- [x] Run `bun run check` to verify linting passes
- [x] Run `bun run --filter backend test` - 46 tests pass (2 new tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)