### PR TITLE
Consolidate API response types and transformers in shared package

### DIFF
--- a/packages/frontend/src/api/projects.ts
+++ b/packages/frontend/src/api/projects.ts
@@ -1,31 +1,6 @@
+import { type ProjectResponse, toProject } from "shared/api";
 import type { Project } from "shared/types";
 import { apiPost } from "./client";
-
-export interface ProjectResponse {
-  id: string;
-  name: string;
-  description: string | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface RepositoryResponse {
-  id: string;
-  name: string;
-  path: string;
-  defaultBranch: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-function toProject(response: ProjectResponse): Project {
-  return {
-    ...response,
-    description: response.description ?? undefined,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-  };
-}
 
 export async function createProject(
   name: string,

--- a/packages/frontend/src/api/repositories.ts
+++ b/packages/frontend/src/api/repositories.ts
@@ -1,46 +1,6 @@
+import { type TaskResponse, toTask } from "shared/api";
 import type { Task } from "shared/types";
 import { apiPost } from "./client";
-
-export interface RepositoryResponse {
-  id: string;
-  name: string;
-  path: string;
-  defaultBranch: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface TaskResponse {
-  id: string;
-  repositoryId: string;
-  title: string;
-  description: string | null;
-  status: string;
-  executor: string;
-  branchName: string;
-  baseBranch: string;
-  worktreePath: string | null;
-  createdAt: string;
-  updatedAt: string;
-  startedAt: string | null;
-  completedAt: string | null;
-}
-
-function toTask(response: TaskResponse): Task {
-  return {
-    ...response,
-    description: response.description ?? undefined,
-    status: response.status as Task["status"],
-    executor: response.executor as Task["executor"],
-    worktreePath: response.worktreePath ?? undefined,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-    startedAt: response.startedAt ? new Date(response.startedAt) : undefined,
-    completedAt: response.completedAt
-      ? new Date(response.completedAt)
-      : undefined,
-  };
-}
 
 export interface CreateTaskInput {
   title: string;

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -1,24 +1,11 @@
-import type { Project, Repository } from "shared/types";
+import {
+  type ProjectResponse,
+  type RepositoryResponse,
+  toProject,
+  toRepository,
+} from "shared/api";
 import useSWR from "swr";
 import { fetcher } from "../api/client";
-import type { ProjectResponse, RepositoryResponse } from "../api/projects";
-
-function toProject(response: ProjectResponse): Project {
-  return {
-    ...response,
-    description: response.description ?? undefined,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-  };
-}
-
-function toRepository(response: RepositoryResponse): Repository {
-  return {
-    ...response,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-  };
-}
 
 export function useProjects() {
   const { data, mutate } = useSWR<ProjectResponse[]>("/projects", fetcher, {

--- a/packages/frontend/src/hooks/useRepositories.ts
+++ b/packages/frontend/src/hooks/useRepositories.ts
@@ -1,31 +1,11 @@
-import type { Repository, Task } from "shared/types";
+import {
+  type RepositoryResponse,
+  type TaskResponse,
+  toRepository,
+  toTask,
+} from "shared/api";
 import useSWR from "swr";
 import { fetcher } from "../api/client";
-import type { RepositoryResponse, TaskResponse } from "../api/repositories";
-
-function toRepository(response: RepositoryResponse): Repository {
-  return {
-    ...response,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-  };
-}
-
-function toTask(response: TaskResponse): Task {
-  return {
-    ...response,
-    description: response.description ?? undefined,
-    status: response.status as Task["status"],
-    executor: response.executor as Task["executor"],
-    worktreePath: response.worktreePath ?? undefined,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-    startedAt: response.startedAt ? new Date(response.startedAt) : undefined,
-    completedAt: response.completedAt
-      ? new Date(response.completedAt)
-      : undefined,
-  };
-}
 
 export function useRepository(id: string) {
   const { data } = useSWR<RepositoryResponse>(`/repositories/${id}`, fetcher, {

--- a/packages/shared/api/index.ts
+++ b/packages/shared/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./responses";
+export * from "./transformers";

--- a/packages/shared/api/responses.ts
+++ b/packages/shared/api/responses.ts
@@ -1,0 +1,51 @@
+/**
+ * API Response types - These represent the JSON structure returned by the backend.
+ * Dates are serialized as ISO 8601 strings.
+ */
+
+export interface ProjectResponse {
+  id: string;
+  name: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RepositoryResponse {
+  id: string;
+  name: string;
+  path: string;
+  defaultBranch: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectRepositoryResponse {
+  projectId: string;
+  repositoryId: string;
+  createdAt: string;
+}
+
+export interface TaskResponse {
+  id: string;
+  repositoryId: string;
+  title: string;
+  description: string | null;
+  status: string;
+  executor: string;
+  branchName: string;
+  baseBranch: string;
+  worktreePath: string | null;
+  createdAt: string;
+  updatedAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface ExecutionLogResponse {
+  id: string;
+  taskId: string;
+  content: string;
+  logType: string;
+  createdAt: string;
+}

--- a/packages/shared/api/transformers.ts
+++ b/packages/shared/api/transformers.ts
@@ -1,0 +1,68 @@
+/**
+ * Transformation functions to convert API responses to domain types.
+ */
+
+import type {
+  ExecutionLog,
+  Project,
+  ProjectRepository,
+  Repository,
+  Task,
+} from "../types";
+import type {
+  ExecutionLogResponse,
+  ProjectRepositoryResponse,
+  ProjectResponse,
+  RepositoryResponse,
+  TaskResponse,
+} from "./responses";
+
+export function toProject(response: ProjectResponse): Project {
+  return {
+    ...response,
+    description: response.description ?? undefined,
+    createdAt: new Date(response.createdAt),
+    updatedAt: new Date(response.updatedAt),
+  };
+}
+
+export function toRepository(response: RepositoryResponse): Repository {
+  return {
+    ...response,
+    createdAt: new Date(response.createdAt),
+    updatedAt: new Date(response.updatedAt),
+  };
+}
+
+export function toProjectRepository(
+  response: ProjectRepositoryResponse,
+): ProjectRepository {
+  return {
+    ...response,
+    createdAt: new Date(response.createdAt),
+  };
+}
+
+export function toTask(response: TaskResponse): Task {
+  return {
+    ...response,
+    description: response.description ?? undefined,
+    status: response.status as Task["status"],
+    executor: response.executor as Task["executor"],
+    worktreePath: response.worktreePath ?? undefined,
+    createdAt: new Date(response.createdAt),
+    updatedAt: new Date(response.updatedAt),
+    startedAt: response.startedAt ? new Date(response.startedAt) : undefined,
+    completedAt: response.completedAt
+      ? new Date(response.completedAt)
+      : undefined,
+  };
+}
+
+export function toExecutionLog(response: ExecutionLogResponse): ExecutionLog {
+  return {
+    ...response,
+    logType: response.logType as ExecutionLog["logType"],
+    createdAt: new Date(response.createdAt),
+  };
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,6 +2,8 @@
   "name": "shared",
   "private": true,
   "type": "module",
-  "main": "./types/index.ts",
-  "types": "./types/index.ts"
+  "exports": {
+    "./types": "./types/index.ts",
+    "./api": "./api/index.ts"
+  }
 }


### PR DESCRIPTION
## Summary
- Add `shared/api/responses.ts` with API response type definitions (ProjectResponse, RepositoryResponse, TaskResponse, etc.)
- Add `shared/api/transformers.ts` with transformation functions (toProject, toRepository, toTask, etc.)
- Update shared package.json with exports for `shared/types` and `shared/api`
- Refactor frontend to import types and transformers from `shared/api`
- Remove duplicated type definitions and transformation functions from frontend

## Benefits
- Single source of truth for API response types
- Reusable transformation logic
- Backend can also use these types for response typing
- Easier maintenance when API changes

## Test plan
- [x] Run `bun run check` to verify linting passes
- [x] Run `bun run --filter frontend build` to verify build succeeds
- [x] Run `bun run --filter backend test` - 46 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)