### PR TITLE
Use Zod schemas for API response parsing and validation

### DIFF
--- a/packages/frontend/src/api/projects.ts
+++ b/packages/frontend/src/api/projects.ts
@@ -1,39 +1,13 @@
-import type { Project } from "shared/types";
+import { Project, type Project as ProjectType } from "shared/schemas";
 import { apiPost } from "./client";
-
-export interface ProjectResponse {
-  id: string;
-  name: string;
-  description: string | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface RepositoryResponse {
-  id: string;
-  name: string;
-  path: string;
-  defaultBranch: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-function toProject(response: ProjectResponse): Project {
-  return {
-    ...response,
-    description: response.description ?? undefined,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-  };
-}
 
 export async function createProject(
   name: string,
   description?: string,
-): Promise<Project> {
-  const data = await apiPost<ProjectResponse>("/projects", {
+): Promise<ProjectType> {
+  const data = await apiPost("/projects", {
     name,
     description,
   });
-  return toProject(data);
+  return Project.parse(data);
 }

--- a/packages/frontend/src/api/repositories.ts
+++ b/packages/frontend/src/api/repositories.ts
@@ -1,46 +1,5 @@
-import type { Task } from "shared/types";
+import { Task, type Task as TaskType } from "shared/schemas";
 import { apiPost } from "./client";
-
-export interface RepositoryResponse {
-  id: string;
-  name: string;
-  path: string;
-  defaultBranch: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface TaskResponse {
-  id: string;
-  repositoryId: string;
-  title: string;
-  description: string | null;
-  status: string;
-  executor: string;
-  branchName: string;
-  baseBranch: string;
-  worktreePath: string | null;
-  createdAt: string;
-  updatedAt: string;
-  startedAt: string | null;
-  completedAt: string | null;
-}
-
-function toTask(response: TaskResponse): Task {
-  return {
-    ...response,
-    description: response.description ?? undefined,
-    status: response.status as Task["status"],
-    executor: response.executor as Task["executor"],
-    worktreePath: response.worktreePath ?? undefined,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-    startedAt: response.startedAt ? new Date(response.startedAt) : undefined,
-    completedAt: response.completedAt
-      ? new Date(response.completedAt)
-      : undefined,
-  };
-}
 
 export interface CreateTaskInput {
   title: string;
@@ -53,10 +12,7 @@ export interface CreateTaskInput {
 export async function createTask(
   repositoryId: string,
   input: CreateTaskInput,
-): Promise<Task> {
-  const data = await apiPost<TaskResponse>(
-    `/repositories/${repositoryId}/tasks`,
-    input,
-  );
-  return toTask(data);
+): Promise<TaskType> {
+  const data = await apiPost(`/repositories/${repositoryId}/tasks`, input);
+  return Task.parse(data);
 }

--- a/packages/frontend/src/components/KanbanBoard.tsx
+++ b/packages/frontend/src/components/KanbanBoard.tsx
@@ -1,5 +1,4 @@
-import type { Task } from "shared/types";
-import { Status } from "shared/types";
+import type { Task } from "shared/schemas";
 import { TaskCard } from "./TaskCard";
 
 interface KanbanBoardProps {
@@ -7,10 +6,10 @@ interface KanbanBoardProps {
 }
 
 const COLUMNS: { status: Task["status"]; label: string }[] = [
-  { status: Status.TODO, label: "TODO" },
-  { status: Status.InProgress, label: "In Progress" },
-  { status: Status.InReview, label: "In Review" },
-  { status: Status.Done, label: "Done" },
+  { status: "TODO", label: "TODO" },
+  { status: "InProgress", label: "In Progress" },
+  { status: "InReview", label: "In Review" },
+  { status: "Done", label: "Done" },
 ];
 
 export function KanbanBoard({ tasks }: KanbanBoardProps) {

--- a/packages/frontend/src/components/TaskCard.tsx
+++ b/packages/frontend/src/components/TaskCard.tsx
@@ -1,4 +1,4 @@
-import type { Task } from "shared/types";
+import type { Task } from "shared/schemas";
 
 interface TaskCardProps {
   task: Task;

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -1,47 +1,27 @@
-import type { Project, Repository } from "shared/types";
+import { Project, ProjectArray, RepositoryArray } from "shared/schemas";
 import useSWR from "swr";
 import { fetcher } from "../api/client";
-import type { ProjectResponse, RepositoryResponse } from "../api/projects";
-
-function toProject(response: ProjectResponse): Project {
-  return {
-    ...response,
-    description: response.description ?? undefined,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-  };
-}
-
-function toRepository(response: RepositoryResponse): Repository {
-  return {
-    ...response,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-  };
-}
 
 export function useProjects() {
-  const { data, mutate } = useSWR<ProjectResponse[]>("/projects", fetcher, {
+  const { data, mutate } = useSWR("/projects", fetcher, {
     suspense: true,
   });
   return {
-    projects: data?.map(toProject) ?? [],
+    projects: ProjectArray.parse(data),
     mutate,
   };
 }
 
 export function useProject(id: string) {
-  const { data } = useSWR<ProjectResponse>(`/projects/${id}`, fetcher, {
+  const { data } = useSWR(`/projects/${id}`, fetcher, {
     suspense: true,
   });
-  return data ? toProject(data) : null;
+  return Project.parse(data);
 }
 
 export function useProjectRepositories(projectId: string) {
-  const { data } = useSWR<RepositoryResponse[]>(
-    `/projects/${projectId}/repositories`,
-    fetcher,
-    { suspense: true },
-  );
-  return data?.map(toRepository) ?? [];
+  const { data } = useSWR(`/projects/${projectId}/repositories`, fetcher, {
+    suspense: true,
+  });
+  return RepositoryArray.parse(data);
 }

--- a/packages/frontend/src/hooks/useRepositories.ts
+++ b/packages/frontend/src/hooks/useRepositories.ts
@@ -1,47 +1,22 @@
-import type { Repository, Task } from "shared/types";
+import { Repository, TaskArray } from "shared/schemas";
 import useSWR from "swr";
 import { fetcher } from "../api/client";
-import type { RepositoryResponse, TaskResponse } from "../api/repositories";
-
-function toRepository(response: RepositoryResponse): Repository {
-  return {
-    ...response,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-  };
-}
-
-function toTask(response: TaskResponse): Task {
-  return {
-    ...response,
-    description: response.description ?? undefined,
-    status: response.status as Task["status"],
-    executor: response.executor as Task["executor"],
-    worktreePath: response.worktreePath ?? undefined,
-    createdAt: new Date(response.createdAt),
-    updatedAt: new Date(response.updatedAt),
-    startedAt: response.startedAt ? new Date(response.startedAt) : undefined,
-    completedAt: response.completedAt
-      ? new Date(response.completedAt)
-      : undefined,
-  };
-}
 
 export function useRepository(id: string) {
-  const { data } = useSWR<RepositoryResponse>(`/repositories/${id}`, fetcher, {
+  const { data } = useSWR(`/repositories/${id}`, fetcher, {
     suspense: true,
   });
-  return data ? toRepository(data) : null;
+  return Repository.parse(data);
 }
 
 export function useRepositoryTasks(repositoryId: string) {
-  const { data, mutate } = useSWR<TaskResponse[]>(
+  const { data, mutate } = useSWR(
     `/repositories/${repositoryId}/tasks`,
     fetcher,
     { suspense: true },
   );
   return {
-    tasks: data?.map(toTask) ?? [],
+    tasks: TaskArray.parse(data),
     mutate,
   };
 }

--- a/packages/frontend/src/pages/RepositoryDetail.tsx
+++ b/packages/frontend/src/pages/RepositoryDetail.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { Executor } from "shared/types";
 import { createTask } from "../api";
 import { KanbanBoard } from "../components";
 import { useRepository, useRepositoryTasks } from "../hooks";
@@ -21,7 +20,7 @@ function RepositoryDetailContent({ repositoryId }: { repositoryId: string }) {
   const [showForm, setShowForm] = useState(false);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [executor, setExecutor] = useState<string>(Executor.ClaudeCode);
+  const [executor, setExecutor] = useState<string>("ClaudeCode");
   const [branchName, setBranchName] = useState("");
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -114,8 +113,8 @@ function RepositoryDetailContent({ repositoryId }: { repositoryId: string }) {
                   value={executor}
                   onChange={(e) => setExecutor(e.target.value)}
                 >
-                  <option value={Executor.ClaudeCode}>Claude Code</option>
-                  <option value={Executor.Codex}>Codex</option>
+                  <option value="ClaudeCode">Claude Code</option>
+                  <option value="Codex">Codex</option>
                 </select>
               </div>
               <div style={{ marginBottom: "8px" }}>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,6 +2,11 @@
   "name": "shared",
   "private": true,
   "type": "module",
-  "main": "./types/index.ts",
-  "types": "./types/index.ts"
+  "exports": {
+    "./types": "./types/index.ts",
+    "./schemas": "./schemas/index.ts"
+  },
+  "dependencies": {
+    "zod": "^4.1.13"
+  }
 }

--- a/packages/shared/schemas/index.ts
+++ b/packages/shared/schemas/index.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+
+// Helper for nullable to optional transformation
+const nullToUndefined = <T>(val: T | null): T | undefined =>
+  val === null ? undefined : val;
+
+// Status enum
+export const Status = z.enum(["TODO", "InProgress", "InReview", "Done"]);
+export type Status = z.infer<typeof Status>;
+
+// Executor enum
+export const Executor = z.enum(["ClaudeCode", "Codex"]);
+export type Executor = z.infer<typeof Executor>;
+
+// LogType enum
+export const LogType = z.enum(["stdout", "stderr", "system"]);
+export type LogType = z.infer<typeof LogType>;
+
+// Project schema - parses API response and transforms dates
+export const Project = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z
+    .string()
+    .nullable()
+    .transform(nullToUndefined)
+    .pipe(z.string().optional()),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+export type Project = z.infer<typeof Project>;
+
+// Repository schema
+export const Repository = z.object({
+  id: z.string(),
+  name: z.string(),
+  path: z.string(),
+  defaultBranch: z.string(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+export type Repository = z.infer<typeof Repository>;
+
+// ProjectRepository schema
+export const ProjectRepository = z.object({
+  projectId: z.string(),
+  repositoryId: z.string(),
+  createdAt: z.coerce.date(),
+});
+export type ProjectRepository = z.infer<typeof ProjectRepository>;
+
+// Task schema
+export const Task = z.object({
+  id: z.string(),
+  repositoryId: z.string(),
+  title: z.string(),
+  description: z
+    .string()
+    .nullable()
+    .transform(nullToUndefined)
+    .pipe(z.string().optional()),
+  status: Status,
+  executor: Executor,
+  branchName: z.string(),
+  baseBranch: z.string(),
+  worktreePath: z
+    .string()
+    .nullable()
+    .transform(nullToUndefined)
+    .pipe(z.string().optional()),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+  startedAt: z.coerce
+    .date()
+    .nullable()
+    .transform(nullToUndefined)
+    .pipe(z.date().optional()),
+  completedAt: z.coerce
+    .date()
+    .nullable()
+    .transform(nullToUndefined)
+    .pipe(z.date().optional()),
+});
+export type Task = z.infer<typeof Task>;
+
+// ExecutionLog schema
+export const ExecutionLog = z.object({
+  id: z.string(),
+  taskId: z.string(),
+  content: z.string(),
+  logType: LogType,
+  createdAt: z.coerce.date(),
+});
+export type ExecutionLog = z.infer<typeof ExecutionLog>;
+
+// Array schemas for parsing lists
+export const ProjectArray = z.array(Project);
+export const RepositoryArray = z.array(Repository);
+export const TaskArray = z.array(Task);
+export const ExecutionLogArray = z.array(ExecutionLog);


### PR DESCRIPTION
## Summary
- Add Zod to shared package
- Create `schemas/index.ts` with Zod schemas for all domain types (Project, Repository, Task, etc.)
- Schemas handle parsing, validation, and date conversion in one place using `z.coerce.date()`
- Update frontend hooks to use `Schema.parse()` for type-safe parsing
- Update frontend API functions to use Zod schemas
- Remove manual type definitions and transformation functions from frontend

## Before
```typescript
// frontend/src/hooks/useProjects.ts
function toProject(response: ProjectResponse): Project {
  return {
    ...response,
    description: response.description ?? undefined,
    createdAt: new Date(response.createdAt),
    updatedAt: new Date(response.updatedAt),
  };
}

const data = await fetcher<ProjectResponse[]>("/projects");
return data?.map(toProject) ?? [];
```

## After
```typescript
// frontend/src/hooks/useProjects.ts
import { ProjectArray } from "shared/schemas";

const { data } = useSWR("/projects", fetcher, { suspense: true });
return ProjectArray.parse(data);
```

## Benefits
- Single source of truth for data shape
- Runtime validation of API responses
- Automatic date string → Date conversion via `z.coerce.date()`
- Type inference from schemas (`z.infer<typeof Schema>`)
- -150 lines, +138 lines (net -12 lines)

## Test plan
- [x] Run `bun run check` - linting passes
- [x] Run `bun run --filter frontend build` - build succeeds
- [x] Run `bun run --filter backend test` - 46 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)