### PR TITLE
feat: Add drag and drop functionality to Kanban board

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,6 +8,9 @@
     "preview": "bunx --bun vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "jotai": "^2.15.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -20,6 +20,18 @@ export async function apiPost<T>(path: string, body: unknown): Promise<T> {
   return response.json();
 }
 
+export async function apiPut<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+  return response.json();
+}
+
 export async function apiDelete(path: string): Promise<void> {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     method: "DELETE",

--- a/packages/frontend/src/api/repositories.ts
+++ b/packages/frontend/src/api/repositories.ts
@@ -1,5 +1,5 @@
-import { Task, type Task as TaskType } from "shared/schemas";
-import { apiPost } from "./client";
+import { type Status, Task, type Task as TaskType } from "shared/schemas";
+import { apiPost, apiPut } from "./client";
 
 export interface CreateTaskInput {
   title: string;
@@ -14,5 +14,13 @@ export async function createTask(
   input: CreateTaskInput,
 ): Promise<TaskType> {
   const data = await apiPost(`/repositories/${repositoryId}/tasks`, input);
+  return Task.parse(data);
+}
+
+export async function updateTaskStatus(
+  taskId: string,
+  status: Status,
+): Promise<TaskType> {
+  const data = await apiPut(`/tasks/${taskId}`, { status });
   return Task.parse(data);
 }

--- a/packages/frontend/src/components/DroppableColumn.tsx
+++ b/packages/frontend/src/components/DroppableColumn.tsx
@@ -1,0 +1,51 @@
+import { useDroppable } from "@dnd-kit/core";
+import type { ReactNode } from "react";
+import type { Status } from "shared/schemas";
+
+interface DroppableColumnProps {
+  status: Status;
+  label: string;
+  children: ReactNode;
+  isValidDrop: boolean;
+  isActive: boolean;
+}
+
+export function DroppableColumn({
+  status,
+  label,
+  children,
+  isValidDrop,
+  isActive,
+}: DroppableColumnProps) {
+  const { isOver, setNodeRef } = useDroppable({
+    id: status,
+  });
+
+  const getBackgroundColor = () => {
+    if (!isActive) return "#f5f5f5";
+    if (isOver && isValidDrop) return "#d4edda";
+    if (isOver && !isValidDrop) return "#f8d7da";
+    if (isValidDrop) return "#e8f5e9";
+    return "#f5f5f5";
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        backgroundColor: getBackgroundColor(),
+        borderRadius: "4px",
+        padding: "8px",
+        minHeight: "200px",
+        transition: "background-color 0.2s ease",
+        border:
+          isOver && isValidDrop
+            ? "2px dashed #28a745"
+            : "2px solid transparent",
+      }}
+    >
+      <h4 style={{ margin: "0 0 12px 0", textAlign: "center" }}>{label}</h4>
+      {children}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/TaskCard.tsx
+++ b/packages/frontend/src/components/TaskCard.tsx
@@ -1,10 +1,13 @@
+import { useDraggable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
 import type { Task } from "shared/schemas";
 
 interface TaskCardProps {
   task: Task;
+  isDragging?: boolean;
 }
 
-export function TaskCard({ task }: TaskCardProps) {
+export function TaskCard({ task, isDragging }: TaskCardProps) {
   return (
     <div
       style={{
@@ -13,6 +16,8 @@ export function TaskCard({ task }: TaskCardProps) {
         padding: "8px",
         marginBottom: "8px",
         backgroundColor: "#fff",
+        opacity: isDragging ? 0.8 : 1,
+        boxShadow: isDragging ? "0 4px 8px rgba(0,0,0,0.2)" : "none",
       }}
     >
       <div style={{ fontWeight: "bold", marginBottom: "4px" }}>
@@ -27,6 +32,29 @@ export function TaskCard({ task }: TaskCardProps) {
         <span>{task.executor}</span>
         <span style={{ marginLeft: "8px" }}>{task.branchName}</span>
       </div>
+    </div>
+  );
+}
+
+interface DraggableTaskCardProps {
+  task: Task;
+}
+
+export function DraggableTaskCard({ task }: DraggableTaskCardProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: task.id,
+    });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    opacity: isDragging ? 0.5 : 1,
+    cursor: "grab",
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...listeners} {...attributes}>
+      <TaskCard task={task} />
     </div>
   );
 }

--- a/packages/frontend/src/components/index.ts
+++ b/packages/frontend/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./DroppableColumn";
 export * from "./KanbanBoard";
 export * from "./Layout";
 export * from "./TaskCard";

--- a/packages/frontend/src/pages/RepositoryDetail.tsx
+++ b/packages/frontend/src/pages/RepositoryDetail.tsx
@@ -146,7 +146,7 @@ function RepositoryDetailContent({ repositoryId }: { repositoryId: string }) {
         )}
       </section>
 
-      <KanbanBoard tasks={tasks} />
+      <KanbanBoard tasks={tasks} onTaskUpdate={mutate} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Implement drag and drop for task status changes using @dnd-kit library
- Add state transition validation to restrict invalid status movements
- Provide visual feedback for valid/invalid drop targets during drag

## Changes
- Added `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` packages
- Created `DroppableColumn` component with visual feedback
- Updated `TaskCard` to support dragging via `DraggableTaskCard`
- Enhanced `KanbanBoard` with DnD context and handlers
- Added `updateTaskStatus` API function
- Added `apiPut` helper to client

## State Transition Rules
- **TODO** → InProgress
- **InProgress** → TODO, InReview
- **InReview** → InProgress, Done
- **Done** → InReview

## Test plan
- [ ] Drag a task from TODO to InProgress - should succeed
- [ ] Drag a task from TODO to Done - should fail (no visual feedback, drop ignored)
- [ ] Drag a task from InProgress to InReview - should succeed
- [ ] Verify task list refreshes after successful drop
- [ ] Verify visual feedback shows green for valid targets, red for invalid on hover

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)