### PR TITLE
feat: Implement Worktree service for git worktree operations

### DIFF
--- a/packages/backend/src/services/worktree.ts
+++ b/packages/backend/src/services/worktree.ts
@@ -1,0 +1,96 @@
+import { $ } from "bun";
+import { GitError } from "./git";
+
+export interface Worktree {
+  path: string;
+  head: string;
+  branch?: string;
+  bare?: boolean;
+  detached?: boolean;
+}
+
+export async function createWorktree(
+  repoPath: string,
+  worktreePath: string,
+  branch: string,
+): Promise<void> {
+  const result =
+    await $`git -C ${repoPath} worktree add ${worktreePath} ${branch}`
+      .nothrow()
+      .quiet();
+
+  if (result.exitCode !== 0) {
+    throw new GitError(
+      `Failed to create worktree at '${worktreePath}'`,
+      result.stderr.toString(),
+    );
+  }
+}
+
+export async function deleteWorktree(
+  repoPath: string,
+  worktreePath: string,
+  force = false,
+): Promise<void> {
+  const args = force
+    ? ["worktree", "remove", "--force"]
+    : ["worktree", "remove"];
+
+  const result = await $`git -C ${repoPath} ${args} ${worktreePath}`
+    .nothrow()
+    .quiet();
+
+  if (result.exitCode !== 0) {
+    throw new GitError(
+      `Failed to delete worktree at '${worktreePath}'`,
+      result.stderr.toString(),
+    );
+  }
+}
+
+export async function listWorktrees(repoPath: string): Promise<Worktree[]> {
+  const result = await $`git -C ${repoPath} worktree list --porcelain`
+    .nothrow()
+    .quiet();
+
+  if (result.exitCode !== 0) {
+    throw new GitError("Failed to list worktrees", result.stderr.toString());
+  }
+
+  return parseWorktreeList(result.stdout.toString());
+}
+
+function parseWorktreeList(output: string): Worktree[] {
+  const worktrees: Worktree[] = [];
+  const lines = output.trim().split("\n");
+
+  let current: Partial<Worktree> = {};
+
+  for (const line of lines) {
+    if (line === "") {
+      if (current.path && current.head) {
+        worktrees.push(current as Worktree);
+      }
+      current = {};
+      continue;
+    }
+
+    if (line.startsWith("worktree ")) {
+      current.path = line.slice(9);
+    } else if (line.startsWith("HEAD ")) {
+      current.head = line.slice(5);
+    } else if (line.startsWith("branch ")) {
+      current.branch = line.slice(7);
+    } else if (line === "bare") {
+      current.bare = true;
+    } else if (line === "detached") {
+      current.detached = true;
+    }
+  }
+
+  if (current.path && current.head) {
+    worktrees.push(current as Worktree);
+  }
+
+  return worktrees;
+}


### PR DESCRIPTION
## Summary
- Add Worktree service module at `backend/src/services/worktree.ts`
- Implement `createWorktree`, `deleteWorktree`, and `listWorktrees` functions
- Parse porcelain output for structured worktree data

## Functions

### `createWorktree(repoPath, worktreePath, branch)`
Creates a new worktree at the specified path for the given branch.

### `deleteWorktree(repoPath, worktreePath, force?)`
Removes a worktree. Use `force=true` to remove even with uncommitted changes.

### `listWorktrees(repoPath)`
Returns all worktrees with parsed metadata:
```typescript
interface Worktree {
  path: string;
  head: string;
  branch?: string;
  bare?: boolean;
  detached?: boolean;
}
```

## Error Handling
Reuses `GitError` from git service for consistent error handling across git operations.

## Test plan
- [ ] Create a worktree for an existing branch
- [ ] List worktrees and verify parsed output
- [ ] Delete a worktree
- [ ] Force delete a worktree with uncommitted changes
- [ ] Verify error handling for invalid paths/branches

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)