### PR TITLE
feat: Define common Executor interface for AI agents

### DIFF
--- a/packages/backend/src/executors/interface.ts
+++ b/packages/backend/src/executors/interface.ts
@@ -1,0 +1,36 @@
+export type LogType = "stdout" | "stderr" | "system";
+
+export interface ExecutorOutput {
+  content: string;
+  logType: LogType;
+}
+
+export type OutputCallback = (output: ExecutorOutput) => void;
+
+export interface ExecutorConfig {
+  taskId: string;
+  workingDirectory: string;
+  prompt: string;
+}
+
+export interface Executor {
+  /**
+   * Start the agent with the given configuration
+   */
+  start(config: ExecutorConfig): Promise<void>;
+
+  /**
+   * Stop the agent
+   */
+  stop(): Promise<void>;
+
+  /**
+   * Send a follow-up message to the agent
+   */
+  sendMessage(message: string): Promise<void>;
+
+  /**
+   * Register a callback for agent output
+   */
+  onOutput(callback: OutputCallback): void;
+}


### PR DESCRIPTION
## Summary
- Define common Executor interface at `backend/src/executors/interface.ts`
- Provide foundation for implementing AI agent executors (ClaudeCode, Codex)

## Interface

### `Executor`
```typescript
interface Executor {
  start(config: ExecutorConfig): Promise<void>;
  stop(): Promise<void>;
  sendMessage(message: string): Promise<void>;
  onOutput(callback: OutputCallback): void;
}
```

### `ExecutorConfig`
```typescript
interface ExecutorConfig {
  taskId: string;
  workingDirectory: string;
  prompt: string;
}
```

### `ExecutorOutput`
```typescript
interface ExecutorOutput {
  content: string;
  logType: LogType; // "stdout" | "stderr" | "system"
}
```

## Usage
This interface will be implemented by specific executor classes:
- `ClaudeCodeExecutor` - For Claude Code agent
- `CodexExecutor` - For Codex agent

## Test plan
- [ ] Interface compiles without errors
- [ ] Can be imported and used as a type constraint
- [ ] Future executor implementations satisfy the interface

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)