### PR TITLE
feat: Add missing frontend API wrapper functions

### DIFF
--- a/packages/frontend/src/api/projects.ts
+++ b/packages/frontend/src/api/projects.ts
@@ -1,5 +1,10 @@
-import { Project, type Project as ProjectType } from "shared/schemas";
-import { apiPost } from "./client";
+import {
+  Project,
+  ProjectRepository,
+  type ProjectRepository as ProjectRepositoryType,
+  type Project as ProjectType,
+} from "shared/schemas";
+import { apiDelete, apiPost, apiPut } from "./client";
 
 export async function createProject(
   name: string,
@@ -10,4 +15,34 @@ export async function createProject(
     description,
   });
   return Project.parse(data);
+}
+
+export async function updateProject(
+  projectId: string,
+  updates: { name?: string; description?: string },
+): Promise<ProjectType> {
+  const data = await apiPut(`/projects/${projectId}`, updates);
+  return Project.parse(data);
+}
+
+export async function deleteProject(projectId: string): Promise<void> {
+  await apiDelete(`/projects/${projectId}`);
+}
+
+export async function associateRepositoryWithProject(
+  projectId: string,
+  repositoryId: string,
+): Promise<ProjectRepositoryType> {
+  const data = await apiPost(
+    `/projects/${projectId}/repositories/${repositoryId}`,
+    {},
+  );
+  return ProjectRepository.parse(data);
+}
+
+export async function disassociateRepositoryFromProject(
+  projectId: string,
+  repositoryId: string,
+): Promise<void> {
+  await apiDelete(`/projects/${projectId}/repositories/${repositoryId}`);
 }

--- a/packages/frontend/src/api/repositories.ts
+++ b/packages/frontend/src/api/repositories.ts
@@ -1,5 +1,53 @@
-import { type Status, Task, type Task as TaskType } from "shared/schemas";
-import { apiPost, apiPut } from "./client";
+import {
+  Repository,
+  RepositoryArray,
+  type Repository as RepositoryType,
+  type Status,
+  Task,
+  type Task as TaskType,
+} from "shared/schemas";
+import { apiDelete, apiPost, apiPut, fetcher } from "./client";
+
+// Repository CRUD operations
+
+export async function getRepositories(): Promise<RepositoryType[]> {
+  const data = await fetcher("/repositories");
+  return RepositoryArray.parse(data);
+}
+
+export async function getRepository(
+  repositoryId: string,
+): Promise<RepositoryType> {
+  const data = await fetcher(`/repositories/${repositoryId}`);
+  return Repository.parse(data);
+}
+
+export interface CreateRepositoryInput {
+  name: string;
+  path: string;
+  defaultBranch?: string;
+}
+
+export async function createRepository(
+  input: CreateRepositoryInput,
+): Promise<RepositoryType> {
+  const data = await apiPost("/repositories", input);
+  return Repository.parse(data);
+}
+
+export async function updateRepository(
+  repositoryId: string,
+  updates: { name?: string; path?: string; defaultBranch?: string },
+): Promise<RepositoryType> {
+  const data = await apiPut(`/repositories/${repositoryId}`, updates);
+  return Repository.parse(data);
+}
+
+export async function deleteRepository(repositoryId: string): Promise<void> {
+  await apiDelete(`/repositories/${repositoryId}`);
+}
+
+// Task operations for repositories
 
 export interface CreateTaskInput {
   title: string;

--- a/packages/frontend/src/api/tasks.ts
+++ b/packages/frontend/src/api/tasks.ts
@@ -5,7 +5,7 @@ import {
   Task,
   type Task as TaskType,
 } from "shared/schemas";
-import { apiPost, fetcher } from "./client";
+import { apiDelete, apiPost, fetcher } from "./client";
 
 export async function getTask(taskId: string): Promise<TaskType> {
   const data = await fetcher(`/tasks/${taskId}`);
@@ -60,6 +60,10 @@ export async function recreateTask(
 export async function getTaskDiff(taskId: string): Promise<string> {
   const data = (await fetcher(`/tasks/${taskId}/diff`)) as { diff: string };
   return data.diff;
+}
+
+export async function deleteTask(taskId: string): Promise<void> {
+  await apiDelete(`/tasks/${taskId}`);
 }
 
 // SSE stream URL for logs


### PR DESCRIPTION
## Summary
- Add wrapper functions for existing backend API endpoints that were previously inaccessible from the frontend
- All wrappers follow existing patterns (error handling, Zod parsing for type safety)

## Changes

### Project API (`projects.ts`)
- `updateProject()` - PUT /v1/projects/:id
- `deleteProject()` - DELETE /v1/projects/:id
- `associateRepositoryWithProject()` - POST /v1/projects/:projectId/repositories/:repositoryId
- `disassociateRepositoryFromProject()` - DELETE /v1/projects/:projectId/repositories/:repositoryId

### Repository API (`repositories.ts`)
- `getRepositories()` - GET /v1/repositories
- `getRepository()` - GET /v1/repositories/:id
- `createRepository()` - POST /v1/repositories
- `updateRepository()` - PUT /v1/repositories/:id
- `deleteRepository()` - DELETE /v1/repositories/:id

### Task API (`tasks.ts`)
- `deleteTask()` - DELETE /v1/tasks/:id

## Test plan
- [ ] Verify TypeScript compilation succeeds
- [ ] Verify all functions are exported correctly from `api/index.ts`
- [ ] Integration with UI components (future PRs)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)