### PR TITLE
feat: Add standalone repository management page

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import {
   ProjectDetail,
   ProjectList,
   RepositoryDetail,
+  RepositoryList,
   TaskDetail,
 } from "./pages";
 
@@ -28,6 +29,14 @@ export function App() {
             element={
               <Suspense fallback={<div>Loading...</div>}>
                 <ProjectDetail />
+              </Suspense>
+            }
+          />
+          <Route
+            path="repositories"
+            element={
+              <Suspense fallback={<div>Loading...</div>}>
+                <RepositoryList />
               </Suspense>
             }
           />

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { FolderKanban, Home, LayoutDashboard } from "lucide-react";
+import { FolderKanban, GitFork, Home, LayoutDashboard } from "lucide-react";
 import { Link, Outlet, useLocation } from "react-router-dom";
 import { cn } from "../lib/utils";
 
@@ -8,6 +8,7 @@ export function Layout() {
   const navItems = [
     { to: "/", label: "Home", icon: Home },
     { to: "/projects", label: "Projects", icon: FolderKanban },
+    { to: "/repositories", label: "Repositories", icon: GitFork },
   ];
 
   return (

--- a/packages/frontend/src/hooks/useRepositories.ts
+++ b/packages/frontend/src/hooks/useRepositories.ts
@@ -1,6 +1,16 @@
-import { Repository, TaskArray } from "shared/schemas";
+import { Repository, RepositoryArray, TaskArray } from "shared/schemas";
 import useSWR from "swr";
 import { fetcher } from "../api/client";
+
+export function useRepositories() {
+  const { data, mutate } = useSWR("/repositories", fetcher, {
+    suspense: true,
+  });
+  return {
+    repositories: RepositoryArray.parse(data),
+    mutate,
+  };
+}
 
 export function useRepository(id: string) {
   const { data, mutate } = useSWR(`/repositories/${id}`, fetcher, {

--- a/packages/frontend/src/pages/RepositoryList.tsx
+++ b/packages/frontend/src/pages/RepositoryList.tsx
@@ -1,0 +1,181 @@
+import { GitBranch, GitFork, Loader2, Plus, X } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { createRepository } from "../api";
+import { Button } from "../components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
+import { useRepositories } from "../hooks";
+
+export function RepositoryList() {
+  const { repositories, mutate } = useRepositories();
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState("");
+  const [path, setPath] = useState("");
+  const [defaultBranch, setDefaultBranch] = useState("main");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCreateRepository = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !path.trim()) return;
+
+    try {
+      setCreating(true);
+      setError(null);
+      await createRepository({
+        name: name.trim(),
+        path: path.trim(),
+        defaultBranch: defaultBranch.trim() || "main",
+      });
+      setName("");
+      setPath("");
+      setDefaultBranch("main");
+      setShowForm(false);
+      mutate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create repository");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Repositories</h1>
+          <p className="text-gray-500">Manage your git repositories</p>
+        </div>
+        {!showForm && (
+          <Button onClick={() => setShowForm(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            New Repository
+          </Button>
+        )}
+      </div>
+
+      {showForm && (
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-lg">Create New Repository</CardTitle>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setShowForm(false)}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {error && (
+              <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-600">
+                {error}
+              </div>
+            )}
+            <form onSubmit={handleCreateRepository} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="repo-name">Name</Label>
+                <Input
+                  id="repo-name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="my-repository"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="repo-path">Path</Label>
+                <Input
+                  id="repo-path"
+                  type="text"
+                  value={path}
+                  onChange={(e) => setPath(e.target.value)}
+                  placeholder="/path/to/repository"
+                  className="font-mono"
+                  required
+                />
+                <p className="text-xs text-gray-500">
+                  Local filesystem path to the git repository
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="repo-branch">Default Branch</Label>
+                <Input
+                  id="repo-branch"
+                  type="text"
+                  value={defaultBranch}
+                  onChange={(e) => setDefaultBranch(e.target.value)}
+                  placeholder="main"
+                />
+              </div>
+              <div className="flex gap-2">
+                <Button type="submit" disabled={creating}>
+                  {creating && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  {creating ? "Creating..." : "Create Repository"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setShowForm(false)}
+                  disabled={creating}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+
+      <div>
+        <h2 className="text-xl font-semibold mb-4">All Repositories</h2>
+        {repositories.length === 0 ? (
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-10">
+              <GitFork className="h-12 w-12 text-gray-400 mb-4" />
+              <p className="text-gray-500">No repositories found.</p>
+              <p className="text-sm text-gray-500">
+                Create your first repository above.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {repositories.map((repo) => (
+              <Link key={repo.id} to={`/repositories/${repo.id}`}>
+                <Card className="hover:bg-gray-50 transition-colors cursor-pointer h-full">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <GitFork className="h-4 w-4" />
+                      {repo.name}
+                    </CardTitle>
+                    <CardDescription className="space-y-1">
+                      <div className="font-mono text-xs truncate">
+                        {repo.path}
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <GitBranch className="h-3 w-3" />
+                        {repo.defaultBranch}
+                      </div>
+                    </CardDescription>
+                  </CardHeader>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/index.ts
+++ b/packages/frontend/src/pages/index.ts
@@ -2,4 +2,5 @@ export * from "./Home";
 export * from "./ProjectDetail";
 export * from "./ProjectList";
 export * from "./RepositoryDetail";
+export * from "./RepositoryList";
 export * from "./TaskDetail";


### PR DESCRIPTION
## Summary
- Add a dedicated `/repositories` page for managing repositories independently from projects
- This reflects the N:N relationship between repositories and projects, allowing repositories to be managed separately
- Add navigation link to the header for easy access

## Changes
- Add `RepositoryList` page with repository listing and create form
- Add `/repositories` route to the router
- Add "Repositories" navigation item to the header layout
- Add `useRepositories` hook for fetching all repositories

## Test plan
- [ ] Navigate to `/repositories` and verify the page loads
- [ ] Create a new repository from the form
- [ ] Click on a repository card to navigate to its detail page
- [ ] Verify the navigation header shows Projects and Repositories as separate links

🤖 Generated with [Claude Code](https://claude.com/claude-code)