### PR TITLE
feat: Update default ports (frontend: 49381, backend: 49382)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ bun install
 bun run dev
 
 # Run individually
-bun run dev:backend   # Hono server on port 3001
-bun run dev:frontend  # Vite dev server on port 3000
+bun run dev:backend   # Hono server on port 49382 (or API_PORT env)
+bun run dev:frontend  # Vite dev server on port 49381 (or PORT env)
 
 # Linting and formatting (Biome)
 bun run lint          # Lint check

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A monorepo project with Hono backend and React frontend.
 
 ```
 sahai/
-├── backend/   # Hono server (port 3001)
-└── frontend/  # React + Vite (port 3000)
+├── backend/   # Hono server (port 49382, or API_PORT env)
+└── frontend/  # React + Vite (port 49381, or PORT env)
 ```
 
 ## Requirements

--- a/bin/sahai.ts
+++ b/bin/sahai.ts
@@ -4,10 +4,12 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
 
+const defaultPort = process.env.API_PORT || "49382";
+
 const { values } = parseArgs({
   args: Bun.argv.slice(2),
   options: {
-    port: { type: "string", short: "p", default: "3001" },
+    port: { type: "string", short: "p", default: defaultPort },
     help: { type: "boolean", short: "h", default: false },
     version: { type: "boolean", short: "v", default: false },
   },
@@ -22,12 +24,12 @@ Usage:
   sahai [options]
 
 Options:
-  -p, --port <port>  Port to run the server on (default: 3001)
+  -p, --port <port>  Port to run the server on (default: 49382, or API_PORT env)
   -h, --help         Show this help message
   -v, --version      Show version number
 
 Examples:
-  sahai              Start the server on port 3001
+  sahai              Start the server on port 49382
   sahai -p 8080      Start the server on port 8080
 `);
   process.exit(0);
@@ -41,7 +43,7 @@ if (values.version) {
   process.exit(0);
 }
 
-const port = Number.parseInt(values.port || "3001", 10);
+const port = Number.parseInt(values.port || defaultPort, 10);
 
 // Find the root directory (where package.json is)
 const rootDir = dirname(import.meta.dir);

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -16,10 +16,11 @@ const app = new Hono();
 const staticDir = process.env.SAHAI_STATIC_DIR;
 const isProduction = !!staticDir;
 
+const frontendPort = process.env.PORT || "49381";
 app.use(
   "*",
   cors({
-    origin: isProduction ? "*" : "http://localhost:3000",
+    origin: isProduction ? "*" : `http://localhost:${frontendPort}`,
     allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization"],
   }),
@@ -57,7 +58,10 @@ if (staticDir) {
   });
 }
 
-const port = Number.parseInt(process.env.SAHAI_PORT || "3001", 10);
+const port = Number.parseInt(
+  process.env.SAHAI_PORT || process.env.API_PORT || "49382",
+  10,
+);
 
 export default {
   port,

--- a/packages/frontend/src/api/__tests__/client.test.ts
+++ b/packages/frontend/src/api/__tests__/client.test.ts
@@ -31,7 +31,7 @@ describe("client API", () => {
 
       expect(result).toEqual(mockData);
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/test",
+        "http://localhost:49382/v1/test",
       );
     });
 
@@ -61,7 +61,7 @@ describe("client API", () => {
 
       expect(result).toEqual(mockResponse);
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/items",
+        "http://localhost:49382/v1/items",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -96,7 +96,7 @@ describe("client API", () => {
 
       expect(result).toEqual(mockResponse);
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/items/1",
+        "http://localhost:49382/v1/items/1",
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
@@ -128,7 +128,7 @@ describe("client API", () => {
       await apiDelete("/items/1");
 
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/items/1",
+        "http://localhost:49382/v1/items/1",
         {
           method: "DELETE",
         },

--- a/packages/frontend/src/api/__tests__/projects.test.ts
+++ b/packages/frontend/src/api/__tests__/projects.test.ts
@@ -39,7 +39,7 @@ describe("projects API", () => {
       expect(project.id).toBe("proj-1");
       expect(project.name).toBe("Test Project");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/projects",
+        "http://localhost:49382/v1/projects",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -73,7 +73,7 @@ describe("projects API", () => {
       expect(project.name).toBe("My Project");
       expect(project.description).toBe("A test project");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/projects",
+        "http://localhost:49382/v1/projects",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/packages/frontend/src/api/__tests__/repositories.test.ts
+++ b/packages/frontend/src/api/__tests__/repositories.test.ts
@@ -52,7 +52,7 @@ describe("repositories API", () => {
       expect(task.title).toBe("Implement feature");
       expect(task.executor).toBe("ClaudeCode");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/repositories/repo-1/tasks",
+        "http://localhost:49382/v1/repositories/repo-1/tasks",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -149,7 +149,7 @@ describe("repositories API", () => {
 
       expect(task.status).toBe("InProgress");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1",
+        "http://localhost:49382/v1/tasks/task-1",
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },

--- a/packages/frontend/src/api/__tests__/tasks.test.ts
+++ b/packages/frontend/src/api/__tests__/tasks.test.ts
@@ -61,7 +61,7 @@ describe("tasks API", () => {
       expect(task.title).toBe("Test Task");
       expect(task.status).toBe("TODO");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1",
+        "http://localhost:49382/v1/tasks/task-1",
       );
     });
 
@@ -101,7 +101,7 @@ describe("tasks API", () => {
       expect(logs).toHaveLength(1);
       expect(logs[0].content).toBe("Test log");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1/logs",
+        "http://localhost:49382/v1/tasks/task-1/logs",
       );
     });
   });
@@ -135,7 +135,7 @@ describe("tasks API", () => {
 
       expect(task.status).toBe("InProgress");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1/start",
+        "http://localhost:49382/v1/tasks/task-1/start",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -173,7 +173,7 @@ describe("tasks API", () => {
       await pauseTask("task-1");
 
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1/pause",
+        "http://localhost:49382/v1/tasks/task-1/pause",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -212,7 +212,7 @@ describe("tasks API", () => {
 
       expect(task.status).toBe("InReview");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1/complete",
+        "http://localhost:49382/v1/tasks/task-1/complete",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -250,7 +250,7 @@ describe("tasks API", () => {
       await resumeTask("task-1", "Please continue with tests");
 
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1/resume",
+        "http://localhost:49382/v1/tasks/task-1/resume",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -286,7 +286,7 @@ describe("tasks API", () => {
       await resumeTask("task-1");
 
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1/resume",
+        "http://localhost:49382/v1/tasks/task-1/resume",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -325,7 +325,7 @@ describe("tasks API", () => {
 
       expect(task.status).toBe("Done");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1/finish",
+        "http://localhost:49382/v1/tasks/task-1/finish",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -367,7 +367,7 @@ describe("tasks API", () => {
 
       expect(task.title).toBe("New Title");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1/recreate",
+        "http://localhost:49382/v1/tasks/task-1/recreate",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -396,7 +396,7 @@ describe("tasks API", () => {
 
       expect(diff).toBe("diff --git a/test.txt b/test.txt\n...");
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "http://localhost:3001/v1/tasks/task-1/diff",
+        "http://localhost:49382/v1/tasks/task-1/diff",
       );
     });
 
@@ -418,7 +418,7 @@ describe("tasks API", () => {
   describe("getTaskLogsStreamUrl", () => {
     test("returns correct SSE URL", () => {
       const url = getTaskLogsStreamUrl("task-123");
-      expect(url).toBe("http://localhost:3001/v1/tasks/task-123/logs/stream");
+      expect(url).toBe("http://localhost:49382/v1/tasks/task-123/logs/stream");
     });
   });
 

--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -5,7 +5,10 @@ const isProductionBrowser =
   !import.meta.env.DEV &&
   typeof document !== "undefined";
 
-const API_BASE_URL = isProductionBrowser ? "/v1" : "http://localhost:3001/v1";
+const API_PORT = "49382";
+const API_BASE_URL = isProductionBrowser
+  ? "/v1"
+  : `http://localhost:${API_PORT}/v1`;
 
 export async function fetcher<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`);

--- a/packages/frontend/src/api/tasks.ts
+++ b/packages/frontend/src/api/tasks.ts
@@ -75,8 +75,9 @@ export async function deleteTask(taskId: string): Promise<void> {
 }
 
 // SSE stream URL for logs
+const API_PORT = "49382";
 export function getTaskLogsStreamUrl(taskId: string): string {
-  return `http://localhost:3001/v1/tasks/${taskId}/logs/stream`;
+  return `http://localhost:${API_PORT}/v1/tasks/${taskId}/logs/stream`;
 }
 
 // Parse SSE log event

--- a/packages/frontend/src/hooks/__tests__/useTasks.test.ts
+++ b/packages/frontend/src/hooks/__tests__/useTasks.test.ts
@@ -160,7 +160,7 @@ describe("useTasks hooks", () => {
       const url = getTaskLogsStreamUrl("task-abc-123");
 
       expect(url).toBe(
-        "http://localhost:3001/v1/tasks/task-abc-123/logs/stream",
+        "http://localhost:49382/v1/tasks/task-abc-123/logs/stream",
       );
     });
   });

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -9,7 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
-    port: 3000,
+    port: Number(process.env.PORT) || 49381,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Change frontend dev server default port from 3000 to 49381
- Change backend API server default port from 3001 to 49382
- Add environment variable support: `PORT` for frontend, `API_PORT` for backend

## Test plan
- [x] All existing tests updated and passing
- [x] CI checks pass
- [ ] Manual verification: `bun run dev` starts servers on new ports
- [ ] Manual verification: `PORT=3000 API_PORT=3001 bun run dev` uses custom ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)