### PR TITLE
feat: Change project creation to modal dialog

### DIFF
--- a/packages/frontend/src/pages/ProjectList.tsx
+++ b/packages/frontend/src/pages/ProjectList.tsx
@@ -1,4 +1,4 @@
-import { FolderPlus, Loader2 } from "lucide-react";
+import { FolderPlus, Loader2, Plus } from "lucide-react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { createProject } from "../api";
@@ -10,19 +10,34 @@ import {
   CardHeader,
   CardTitle,
 } from "../components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../components/ui/dialog";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import { useProjects } from "../hooks";
 
 export function ProjectList() {
   const { projects, mutate } = useProjects();
+  const [createOpen, setCreateOpen] = useState(false);
   const [newProjectName, setNewProjectName] = useState("");
   const [newProjectDescription, setNewProjectDescription] = useState("");
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleCreateProject = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const resetForm = () => {
+    setNewProjectName("");
+    setNewProjectDescription("");
+    setError(null);
+  };
+
+  const handleCreateProject = async () => {
     if (!newProjectName.trim()) return;
 
     try {
@@ -35,6 +50,7 @@ export function ProjectList() {
       setNewProjectName("");
       setNewProjectDescription("");
       mutate();
+      setCreateOpen(false);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create project");
     } finally {
@@ -44,53 +60,74 @@ export function ProjectList() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Projects</h1>
-        <p className="text-gray-500">Manage your projects and repositories</p>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <FolderPlus className="h-5 w-5" />
-            Create New Project
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {error && (
-            <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-600">
-              {error}
-            </div>
-          )}
-          <form onSubmit={handleCreateProject} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="project-name">Name</Label>
-              <Input
-                id="project-name"
-                type="text"
-                value={newProjectName}
-                onChange={(e) => setNewProjectName(e.target.value)}
-                placeholder="Enter project name"
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="project-description">Description</Label>
-              <Input
-                id="project-description"
-                type="text"
-                value={newProjectDescription}
-                onChange={(e) => setNewProjectDescription(e.target.value)}
-                placeholder="Optional description"
-              />
-            </div>
-            <Button type="submit" disabled={creating}>
-              {creating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {creating ? "Creating..." : "Create Project"}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Projects</h1>
+          <p className="text-gray-500">Manage your projects and repositories</p>
+        </div>
+        <Dialog
+          open={createOpen}
+          onOpenChange={(open) => {
+            setCreateOpen(open);
+            if (open) resetForm();
+          }}
+        >
+          <DialogTrigger asChild>
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              New Project
             </Button>
-          </form>
-        </CardContent>
-      </Card>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create New Project</DialogTitle>
+              <DialogDescription>
+                Create a new project to organize your repositories and tasks.
+              </DialogDescription>
+            </DialogHeader>
+            {error && (
+              <div className="rounded-md bg-red-50 p-3 text-sm text-red-600">
+                {error}
+              </div>
+            )}
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="project-name">Name</Label>
+                <Input
+                  id="project-name"
+                  type="text"
+                  value={newProjectName}
+                  onChange={(e) => setNewProjectName(e.target.value)}
+                  placeholder="Enter project name"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="project-description">Description</Label>
+                <Input
+                  id="project-description"
+                  type="text"
+                  value={newProjectDescription}
+                  onChange={(e) => setNewProjectDescription(e.target.value)}
+                  placeholder="Optional description"
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setCreateOpen(false)}
+                disabled={creating}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleCreateProject} disabled={creating}>
+                {creating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Create Project
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
 
       <div>
         <h2 className="text-xl font-semibold mb-4">All Projects</h2>
@@ -99,8 +136,8 @@ export function ProjectList() {
             <CardContent className="flex flex-col items-center justify-center py-10">
               <FolderPlus className="h-12 w-12 text-gray-400 mb-4" />
               <p className="text-gray-500">No projects found.</p>
-              <p className="text-sm text-gray-500">
-                Create your first project above.
+              <p className="text-sm text-gray-400 mt-1">
+                Click "New Project" to create one.
               </p>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- Replace inline card form with modal dialog for creating projects
- Match the existing repository creation UI pattern for consistency
- Update empty state message to reference the new "New Project" button

## Test plan
- [ ] Open Projects page
- [ ] Click "New Project" button and verify modal opens
- [ ] Create a project and verify it appears in the list
- [ ] Verify modal closes after successful creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)