### PR TITLE
feat: Create worktrees in OS temp directory

### DIFF
--- a/packages/backend/src/routes/tasks.ts
+++ b/packages/backend/src/routes/tasks.ts
@@ -1,3 +1,4 @@
+import { tmpdir } from "node:os";
 import { desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
@@ -320,7 +321,7 @@ taskById.post("/:id/start", async (c) => {
   }
 
   const repo = repoResult[0];
-  const worktreePath = `${repo.path}/.worktrees/${task.branchName}`;
+  const worktreePath = `${tmpdir()}/sahai-worktrees/${task.id}`;
 
   try {
     // Create branch from base branch


### PR DESCRIPTION
## Summary
- Move worktree creation from repository-local `.worktrees/` directory to OS temp directory
- Worktrees are now created at `${tmpdir()}/sahai-worktrees/${taskId}`
- Keeps repositories clean and avoids potential issues with worktrees inside the repository

## Test plan
- [ ] Create and start a new task
- [ ] Verify worktree is created in temp directory (e.g., `/tmp/sahai-worktrees/<taskId>`)
- [ ] Verify task execution works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)