### PR TITLE
feat: Add actions dropdown menu to task cards on Kanban board

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,6 +14,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/packages/frontend/src/components/KanbanBoard.tsx
+++ b/packages/frontend/src/components/KanbanBoard.tsx
@@ -103,7 +103,11 @@ export function KanbanBoard({ tasks, onTaskUpdate }: KanbanBoardProps) {
             isActive={!!activeTask}
           >
             {tasksByStatus(column.status).map((task) => (
-              <DraggableTaskCard key={task.id} task={task} />
+              <DraggableTaskCard
+                key={task.id}
+                task={task}
+                onTaskUpdate={onTaskUpdate}
+              />
             ))}
           </DroppableColumn>
         ))}

--- a/packages/frontend/src/components/TaskCard.tsx
+++ b/packages/frontend/src/components/TaskCard.tsx
@@ -1,29 +1,153 @@
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
-import { GitBranch } from "lucide-react";
+import {
+  CheckCircle,
+  GitBranch,
+  Loader2,
+  MoreVertical,
+  Pause,
+  Play,
+  Trash2,
+} from "lucide-react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import type { Task } from "shared/schemas";
+import {
+  completeTask,
+  deleteTask,
+  finishTask,
+  pauseTask,
+  startTask,
+} from "../api";
 import { cn } from "../lib/utils";
+import { Button } from "./ui/button";
 import { Card, CardContent } from "./ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
 
 interface TaskCardProps {
   task: Task;
   isDragging?: boolean;
+  onTaskUpdate?: () => void;
 }
 
-export function TaskCard({ task, isDragging }: TaskCardProps) {
+export function TaskCard({ task, isDragging, onTaskUpdate }: TaskCardProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleAction = async (
+    action: () => Promise<unknown>,
+    e: React.MouseEvent,
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      setLoading(true);
+      await action();
+      onTaskUpdate?.();
+    } catch (error) {
+      console.error("Action failed:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!confirm(`Are you sure you want to delete "${task.title}"?`)) {
+      return;
+    }
+    try {
+      setLoading(true);
+      await deleteTask(task.id);
+      onTaskUpdate?.();
+    } catch (error) {
+      console.error("Delete failed:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <Card
       className={cn("transition-shadow", isDragging && "opacity-80 shadow-lg")}
     >
       <CardContent className="p-3">
-        <Link
-          to={`/tasks/${task.id}`}
-          className="font-medium text-sm hover:underline"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {task.title}
-        </Link>
+        <div className="flex items-start justify-between gap-2">
+          <Link
+            to={`/tasks/${task.id}`}
+            className="font-medium text-sm hover:underline flex-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {task.title}
+          </Link>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0"
+                onClick={(e) => e.stopPropagation()}
+                disabled={loading}
+              >
+                {loading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <MoreVertical className="h-4 w-4" />
+                )}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {task.status === "TODO" && (
+                <DropdownMenuItem
+                  onClick={(e) => handleAction(() => startTask(task.id), e)}
+                >
+                  <Play className="mr-2 h-4 w-4" />
+                  Start
+                </DropdownMenuItem>
+              )}
+              {task.status === "InProgress" && (
+                <>
+                  <DropdownMenuItem
+                    onClick={(e) => handleAction(() => pauseTask(task.id), e)}
+                  >
+                    <Pause className="mr-2 h-4 w-4" />
+                    Pause
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={(e) =>
+                      handleAction(() => completeTask(task.id), e)
+                    }
+                  >
+                    <CheckCircle className="mr-2 h-4 w-4" />
+                    Complete
+                  </DropdownMenuItem>
+                </>
+              )}
+              {task.status === "InReview" && (
+                <DropdownMenuItem
+                  onClick={(e) => handleAction(() => finishTask(task.id), e)}
+                >
+                  <CheckCircle className="mr-2 h-4 w-4" />
+                  Finish
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={handleDelete}
+                className="text-red-600 focus:text-red-600"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
         {task.description && (
           <p className="text-xs text-gray-500 mt-1 line-clamp-2">
             {task.description}
@@ -45,9 +169,13 @@ export function TaskCard({ task, isDragging }: TaskCardProps) {
 
 interface DraggableTaskCardProps {
   task: Task;
+  onTaskUpdate?: () => void;
 }
 
-export function DraggableTaskCard({ task }: DraggableTaskCardProps) {
+export function DraggableTaskCard({
+  task,
+  onTaskUpdate,
+}: DraggableTaskCardProps) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({
       id: task.id,
@@ -64,7 +192,7 @@ export function DraggableTaskCard({ task }: DraggableTaskCardProps) {
       {...listeners}
       {...attributes}
     >
-      <TaskCard task={task} />
+      <TaskCard task={task} onTaskUpdate={onTaskUpdate} />
     </div>
   );
 }

--- a/packages/frontend/src/components/ui/button.tsx
+++ b/packages/frontend/src/components/ui/button.tsx
@@ -1,6 +1,7 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
+import { forwardRef } from "react";
 
 import { cn } from "../../lib/utils";
 
@@ -37,20 +38,18 @@ export interface ButtonProps
   asChild?: boolean;
 }
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: ButtonProps) {
-  const Comp = asChild ? Slot : "button";
-  return (
-    <Comp
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  );
-}
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
 
 export { Button, buttonVariants };

--- a/packages/frontend/src/components/ui/dropdown-menu.tsx
+++ b/packages/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,202 @@
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import type * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      className={cn(
+        "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-gray-100 data-[state=open]:bg-gray-100",
+        inset && "pl-8",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRight className="ml-auto h-4 w-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-gray-200 bg-white p-1 text-gray-950 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 min-w-[8rem] overflow-hidden rounded-md border border-gray-200 bg-white p-1 text-gray-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-gray-100 focus:text-gray-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        inset && "pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-gray-100 focus:text-gray-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-gray-100 focus:text-gray-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Circle className="h-2 w-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      className={cn(
+        "px-2 py-1.5 text-sm font-semibold",
+        inset && "pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      className={cn("-mx-1 my-1 h-px bg-gray-100", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+};


### PR DESCRIPTION
## Summary
Add a dropdown menu to task cards on the Kanban board to enable quick actions without navigating to the task detail page.

## Changes
- Add `@radix-ui/react-dropdown-menu` dependency
- Create `DropdownMenu` UI component (`packages/frontend/src/components/ui/dropdown-menu.tsx`)
- Update `TaskCard` component to include actions dropdown menu
- Pass `onTaskUpdate` callback through `KanbanBoard` to `DraggableTaskCard` for refreshing after actions

## Actions
The dropdown menu includes the following actions based on task status:

| Action | From Status | To Status |
|--------|-------------|-----------|
| Start | TODO | InProgress |
| Pause | InProgress | TODO |
| Complete | InProgress | InReview |
| Finish | InReview | Done |
| Delete | Any | (deleted) |

- Actions are only shown when the task is in the appropriate state
- Delete action shows a confirmation dialog
- Loading spinner is displayed while action is in progress

## Test plan
- [x] Run `bun run ci` - lint and format checks pass
- [x] Run `bun run --filter frontend build` - frontend builds successfully
- [x] Run `bun run --filter frontend test` - all 74 tests pass
- [x] Run `bun run --filter backend test` - all 114 tests pass
- [ ] Manual test: Click dropdown menu on task cards
- [ ] Manual test: Verify each action works correctly

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)