### PR TITLE
feat: Implement Claude Code session resume

### DIFF
--- a/packages/backend/drizzle/0001_sloppy_jack_flag.sql
+++ b/packages/backend/drizzle/0001_sloppy_jack_flag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD `session_id` text;

--- a/packages/backend/drizzle/meta/0001_snapshot.json
+++ b/packages/backend/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,400 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2a9f1147-db15-4f76-a8aa-6f52f399d8aa",
+  "prevId": "f21c8423-dffa-48c2-b118-74e33355ba67",
+  "tables": {
+    "execution_logs": {
+      "name": "execution_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_type": {
+          "name": "log_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_execution_logs_task_id": {
+          "name": "idx_execution_logs_task_id",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "execution_logs_task_id_tasks_id_fk": {
+          "name": "execution_logs_task_id_tasks_id_fk",
+          "tableFrom": "execution_logs",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_repositories": {
+      "name": "project_repositories",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_repositories_project_id": {
+          "name": "idx_project_repositories_project_id",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "idx_project_repositories_repository_id": {
+          "name": "idx_project_repositories_repository_id",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_repositories_project_id_projects_id_fk": {
+          "name": "project_repositories_project_id_projects_id_fk",
+          "tableFrom": "project_repositories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_repositories_repository_id_repositories_id_fk": {
+          "name": "project_repositories_repository_id_repositories_id_fk",
+          "tableFrom": "project_repositories",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_repositories_project_id_repository_id_pk": {
+          "columns": [
+            "project_id",
+            "repository_id"
+          ],
+          "name": "project_repositories_project_id_repository_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executor": {
+          "name": "executor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tasks_repository_id": {
+          "name": "idx_tasks_repository_id",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tasks_status": {
+          "name": "idx_tasks_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_repository_id_repositories_id_fk": {
+          "name": "tasks_repository_id_repositories_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/backend/drizzle/meta/_journal.json
+++ b/packages/backend/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1764404215767,
       "tag": "0000_nosy_moira_mactaggert",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1764503217176,
+      "tag": "0001_sloppy_jack_flag",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -53,6 +53,7 @@ export const tasks = sqliteTable(
     branchName: text("branch_name").notNull(),
     baseBranch: text("base_branch").notNull(),
     worktreePath: text("worktree_path"),
+    sessionId: text("session_id"),
     createdAt: text("created_at").notNull(),
     updatedAt: text("updated_at").notNull(),
     startedAt: text("started_at"),

--- a/packages/backend/src/executors/codex.ts
+++ b/packages/backend/src/executors/codex.ts
@@ -79,6 +79,10 @@ export class CodexExecutor implements Executor {
     this.exitCallback = callback;
   }
 
+  onSessionId(): void {
+    // Codex doesn't use session IDs - no-op
+  }
+
   private emitOutput(output: ExecutorOutput): void {
     this.outputCallback?.(output);
   }

--- a/packages/backend/src/executors/interface.ts
+++ b/packages/backend/src/executors/interface.ts
@@ -7,11 +7,14 @@ export interface ExecutorOutput {
 
 export type OutputCallback = (output: ExecutorOutput) => void;
 export type ExitCallback = (exitCode: number | null) => void;
+export type SessionIdCallback = (sessionId: string) => void;
 
 export interface ExecutorConfig {
   taskId: string;
   workingDirectory: string;
   prompt: string;
+  /** Session ID for resuming a previous session */
+  sessionId?: string;
 }
 
 export interface Executor {
@@ -39,4 +42,9 @@ export interface Executor {
    * Register a callback for when the agent process exits
    */
   onExit(callback: ExitCallback): void;
+
+  /**
+   * Register a callback for when a session ID is detected
+   */
+  onSessionId(callback: SessionIdCallback): void;
 }

--- a/packages/backend/src/routes/tasks.ts
+++ b/packages/backend/src/routes/tasks.ts
@@ -432,6 +432,15 @@ taskById.post("/:id/start", async (c) => {
       handleExecutorExit(id);
     });
 
+    executor.onSessionId(async (sessionId) => {
+      // Save session ID to task for later resume
+      console.log(`[tasks] Saving session ID ${sessionId} for task ${id}`);
+      await db
+        .update(tasks)
+        .set({ sessionId, updatedAt: new Date().toISOString() })
+        .where(eq(tasks.id, id));
+    });
+
     await executor.start({
       taskId: id,
       workingDirectory: worktreePath,
@@ -571,12 +580,22 @@ taskById.post("/:id/resume", async (c) => {
       handleExecutorExit(id);
     });
 
+    executor.onSessionId(async (sessionId) => {
+      // Save session ID to task for later resume
+      console.log(`[tasks] Saving session ID ${sessionId} for task ${id}`);
+      await db
+        .update(tasks)
+        .set({ sessionId, updatedAt: new Date().toISOString() })
+        .where(eq(tasks.id, id));
+    });
+
     const prompt = body.message ?? task.description ?? task.title;
 
     await executor.start({
       taskId: id,
       workingDirectory: task.worktreePath,
       prompt,
+      sessionId: task.sessionId ?? undefined,
     });
 
     activeExecutors.set(id, executor);


### PR DESCRIPTION
## Summary
- Add `sessionId` field to tasks database schema for storing Claude Code session IDs
- Add `SessionIdCallback` to Executor interface for session ID detection
- Extract `session_id` from Claude JSON output and save to task
- Pass `sessionId` with `--resume` flag when resuming a task from InReview state
- Update CodexExecutor with no-op `onSessionId` implementation

This allows Claude Code to properly resume a session when the user sends a follow-up message from the InReview state, maintaining conversation context.

## Test plan
- [ ] Start a new task and verify session_id is extracted and saved
- [ ] After task completes (moves to InReview), send a follow-up message
- [ ] Verify Claude Code resumes with the correct session context

🤖 Generated with [Claude Code](https://claude.com/claude-code)