### PR TITLE
Fix CLI server not staying alive and update default port

### DIFF
--- a/bin/sahai.ts
+++ b/bin/sahai.ts
@@ -4,7 +4,7 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
 
-const defaultPort = process.env.API_PORT || "49382";
+const defaultPort = process.env.PORT || "49831";
 
 const { values } = parseArgs({
   args: Bun.argv.slice(2),
@@ -24,12 +24,12 @@ Usage:
   sahai [options]
 
 Options:
-  -p, --port <port>  Port to run the server on (default: 49382, or API_PORT env)
+  -p, --port <port>  Port to run the server on (default: 49831, or PORT env)
   -h, --help         Show this help message
   -v, --version      Show version number
 
 Examples:
-  sahai              Start the server on port 49382
+  sahai              Start the server on port 49831
   sahai -p 8080      Start the server on port 8080
 `);
   process.exit(0);

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -59,9 +59,14 @@ if (staticDir) {
 }
 
 const port = Number.parseInt(
-  process.env.SAHAI_PORT || process.env.API_PORT || "49382",
+  process.env.SAHAI_PORT || process.env.PORT || "49831",
   10,
 );
+
+export const server = Bun.serve({
+  port,
+  fetch: app.fetch,
+});
 
 export default {
   port,


### PR DESCRIPTION
## Summary
- Fix `bin/sahai.ts` exiting immediately by adding explicit `Bun.serve()` call
- Change default port from 49382 to 49831
- Use `PORT` env var instead of `API_PORT`

## Test plan
- [ ] Run `./bin/sahai.ts` and verify server stays running
- [ ] Verify server starts on port 49831 by default
- [ ] Test `PORT=8080 ./bin/sahai.ts` to verify env override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)