### PR TITLE
Fork codex rollout file before resume

### DIFF
--- a/packages/backend/src/executors/codex.ts
+++ b/packages/backend/src/executors/codex.ts
@@ -1,8 +1,8 @@
-import type { Subprocess } from "bun";
-import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
-import { randomUUID } from "node:crypto";
+import type { Subprocess } from "bun";
 import type {
   Executor,
   ExecutorConfig,


### PR DESCRIPTION
## Summary
- search for codex rollout files and fork them with a new session id before resume
- ensure meta payload includes id and source, write forked rollout under ~/.codex/sessions/yyyy/mm/dd
- pass the forked path to resumeConversation so codex can resume reliably

## Testing
- bun run lint packages/backend/src/executors/codex.ts