### PR TITLE
Add Cmd/Ctrl+Enter shortcut for agent message send

### DIFF
--- a/packages/frontend/src/pages/__tests__/TaskDetail.test.tsx
+++ b/packages/frontend/src/pages/__tests__/TaskDetail.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup } from "@testing-library/react";
 import { Window } from "happy-dom";
 import type { Task } from "shared/schemas";
+import { shouldSubmitChatMessage } from "../TaskDetail";
 
 // Set up happy-dom
 const window = new Window();
@@ -202,6 +203,43 @@ describe("TaskDetail", () => {
       expect(showComplete).toBe(false);
       expect(showResume).toBe(false);
       expect(showFinish).toBe(false);
+    });
+  });
+
+  describe("ChatInput keyboard shortcuts", () => {
+    const canSend = true;
+    const loading = false;
+
+    test("Command+Enter submits message", () => {
+      const shouldSubmit = shouldSubmitChatMessage(
+        {
+          key: "Enter",
+          metaKey: true,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+        },
+        canSend,
+        loading,
+      );
+
+      expect(shouldSubmit).toBe(true);
+    });
+
+    test("Ctrl+Enter submits message", () => {
+      const shouldSubmit = shouldSubmitChatMessage(
+        {
+          key: "Enter",
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          altKey: false,
+        },
+        canSend,
+        loading,
+      );
+
+      expect(shouldSubmit).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- support Cmd+Enter / Ctrl+Enter to submit agent messages from task detail
- centralize key handling in shouldSubmitChatMessage to honor send gating
- add unit tests for the shortcut logic

## Testing
- bun run lint
- bun run --filter frontend test

Fixes #114