### PR TITLE
Add GitHub repository link to header

### DIFF
--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { FolderKanban, GitFork, LayoutDashboard } from "lucide-react";
+import { FolderKanban, GitFork, Github, LayoutDashboard } from "lucide-react";
 import { Link, Outlet, useLocation } from "react-router-dom";
 import { cn } from "../lib/utils";
 
@@ -36,6 +36,17 @@ export function Layout() {
               );
             })}
           </nav>
+          <div className="ml-auto">
+            <a
+              href="https://github.com/hayashikun/sahai"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center rounded-md p-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+              aria-label="GitHub repository"
+            >
+              <Github className="h-5 w-5" />
+            </a>
+          </div>
         </div>
       </header>
       <main className="container mx-auto px-4 py-6">


### PR DESCRIPTION
## Summary
Add a GitHub icon link to the right side of the header navigation that opens the sahai repository.

## Changes
- Added GitHub icon from lucide-react to the header
- Positioned on the right side using `ml-auto`
- Opens in a new tab with proper security attributes (`target="_blank"`, `rel="noopener noreferrer"`)
- Styled to match existing header design with hover effects
- Includes `aria-label` for accessibility

## Testing
- [x] GitHub icon is visible on the right side of the header
- [x] Clicking the link opens https://github.com/hayashikun/sahai in a new tab
- [x] Icon styling matches the existing header design
- [x] Linting and formatting checks pass

Closes #118