### PR TITLE
Change message input to submit with Cmd+Enter instead of Enter

### DIFF
--- a/packages/frontend/src/pages/TaskDetail.tsx
+++ b/packages/frontend/src/pages/TaskDetail.tsx
@@ -847,10 +847,8 @@ export function shouldSubmitChatMessage(
   if (event.key !== "Enter" || loading) return false;
 
   const hasSubmitModifier = event.metaKey || event.ctrlKey;
-  const isPlainEnter =
-    !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey;
 
-  return canSendMessage && (hasSubmitModifier || isPlainEnter);
+  return canSendMessage && hasSubmitModifier;
 }
 
 export function ChatInput({


### PR DESCRIPTION
- Changed Execution Logs message input behavior
- Enter key now only creates a new line
- Command + Enter (or Ctrl + Enter) submits the message