### PR TITLE
feat: add real-time task status updates to Repository Task Board via SSE

### DIFF
--- a/packages/frontend/src/api/tasks.ts
+++ b/packages/frontend/src/api/tasks.ts
@@ -87,11 +87,52 @@ export function getTaskLogsStreamUrl(taskId: string): string {
   return `${API_BASE_URL}/tasks/${taskId}/logs/stream`;
 }
 
+// SSE stream URL for repository task events
+export function getRepositoryTasksStreamUrl(repositoryId: string): string {
+  return `${API_BASE_URL}/repositories/${repositoryId}/tasks/stream`;
+}
+
 // Parse SSE log event
 export function parseLogEvent(data: string): ExecutionLogType | null {
   try {
     const parsed = JSON.parse(data);
     return ExecutionLog.parse(parsed);
+  } catch {
+    return null;
+  }
+}
+
+// Task event types for SSE
+export type TaskStatusChangedEvent = {
+  type: "task-status-changed";
+  taskId: string;
+  oldStatus: string;
+  newStatus: string;
+  isExecuting: boolean;
+  updatedAt: string;
+};
+
+export type TaskCreatedEvent = {
+  type: "task-created";
+  task: TaskType;
+  createdAt: string;
+};
+
+export type TaskDeletedEvent = {
+  type: "task-deleted";
+  taskId: string;
+  deletedAt: string;
+};
+
+export type TaskEvent =
+  | TaskStatusChangedEvent
+  | TaskCreatedEvent
+  | TaskDeletedEvent;
+
+// Parse SSE task event
+export function parseTaskEvent(data: string): TaskEvent | null {
+  try {
+    return JSON.parse(data) as TaskEvent;
   } catch {
     return null;
   }

--- a/packages/frontend/src/pages/RepositoryDetail.tsx
+++ b/packages/frontend/src/pages/RepositoryDetail.tsx
@@ -48,7 +48,11 @@ import {
   SelectValue,
 } from "../components/ui/select";
 import { Textarea } from "../components/ui/textarea";
-import { useRepository, useRepositoryTasks } from "../hooks";
+import {
+  useRepository,
+  useRepositoryTasks,
+  useRepositoryTasksStream,
+} from "../hooks";
 
 export function RepositoryDetail() {
   const { repositoryId } = useParams<{ repositoryId: string }>();
@@ -69,6 +73,13 @@ function RepositoryDetailContent({ repositoryId }: { repositoryId: string }) {
   const { repository, mutate: mutateRepository } = useRepository(repositoryId);
   const { tasks, mutate: mutateTasks } = useRepositoryTasks(repositoryId);
   const navigate = useNavigate();
+
+  // Subscribe to real-time task events via SSE
+  const handleTaskEvent = useCallback(() => {
+    mutateTasks();
+  }, [mutateTasks]);
+
+  useRepositoryTasksStream(repositoryId, handleTaskEvent);
 
   // Task creation state
   const [createTaskOpen, setCreateTaskOpen] = useState(false);

--- a/packages/shared/types/index.ts
+++ b/packages/shared/types/index.ts
@@ -69,3 +69,38 @@ export interface ExecutionLog {
   logType: LogType;
   createdAt: Date;
 }
+
+// Task event types for SSE streaming
+export const TaskEventType = {
+  TaskStatusChanged: "task-status-changed",
+  TaskCreated: "task-created",
+  TaskDeleted: "task-deleted",
+} as const;
+
+export type TaskEventType = (typeof TaskEventType)[keyof typeof TaskEventType];
+
+export interface TaskStatusChangedEvent {
+  type: typeof TaskEventType.TaskStatusChanged;
+  taskId: string;
+  oldStatus: Status;
+  newStatus: Status;
+  isExecuting: boolean;
+  updatedAt: string;
+}
+
+export interface TaskCreatedEvent {
+  type: typeof TaskEventType.TaskCreated;
+  task: Task & { isExecuting: boolean };
+  createdAt: string;
+}
+
+export interface TaskDeletedEvent {
+  type: typeof TaskEventType.TaskDeleted;
+  taskId: string;
+  deletedAt: string;
+}
+
+export type TaskEvent =
+  | TaskStatusChangedEvent
+  | TaskCreatedEvent
+  | TaskDeletedEvent;


### PR DESCRIPTION
## Summary
- Add repository-level SSE endpoint for task events (`GET /v1/repositories/:repositoryId/tasks/stream`)
- Broadcast task-status-changed, task-created, task-deleted events from all relevant endpoints and handleExecutorExit
- Add `useRepositoryTasksStream` hook for frontend SSE subscription
- Integrate SSE with RepositoryDetail page for automatic Kanban updates

Closes #94

## Changes

### Backend (`packages/backend/src/routes/tasks.ts`)
- Added repository-level task event subscriber/broadcast system
- Added SSE endpoint `GET /v1/repositories/:repositoryId/tasks/stream`
- Added event broadcasting to:
  - Task creation (`task-created`)
  - Task status updates (`task-status-changed`)
  - Task deletion (`task-deleted`)
  - Automatic executor completion transition

### Frontend
- `packages/frontend/src/api/tasks.ts`: Added SSE URL generator and event types
- `packages/frontend/src/hooks/useTasks.ts`: Added `useRepositoryTasksStream` hook
- `packages/frontend/src/pages/RepositoryDetail.tsx`: Integrated SSE for real-time updates

### Shared Types (`packages/shared/types/index.ts`)
- Added task event type definitions

## Test plan
- [ ] Open Repository Detail page with Task Board
- [ ] Create a new task and verify it appears automatically
- [ ] Start a task and verify status changes in real-time
- [ ] Complete/Finish a task and verify card moves to correct column
- [ ] Delete a task and verify it disappears from board
- [ ] Open same repository in two browser tabs and verify both update simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)