### PR TITLE
feat: auto-scroll to bottom on Execution Logs page load

### DIFF
--- a/packages/frontend/src/pages/TaskDetail.tsx
+++ b/packages/frontend/src/pages/TaskDetail.tsx
@@ -714,8 +714,15 @@ function ExecutionLogs({ logs, connected, error }: ExecutionLogsProps) {
   const logsEndRef = useRef<HTMLDivElement>(null);
   const logsContainerRef = useRef<HTMLDivElement>(null);
   const prevLogsLengthRef = useRef(logs.length);
+  const hasInitialScrolledRef = useRef(false);
 
   useEffect(() => {
+    // Initial scroll to bottom on mount
+    if (!hasInitialScrolledRef.current && logsEndRef.current) {
+      hasInitialScrolledRef.current = true;
+      logsEndRef.current.scrollIntoView({ behavior: "instant" });
+    }
+
     if (prevLogsLengthRef.current !== logs.length) {
       prevLogsLengthRef.current = logs.length;
 


### PR DESCRIPTION
Automatically scroll to the bottom of logs when navigating to the Execution Logs page.

## Changes
- Add initial scroll to bottom on component mount
- Maintain existing behavior for subsequent log updates (auto-scroll only when user is near bottom)