### PR TITLE
feat: add responsive design support for mobile and tablet

### DIFF
--- a/packages/frontend/src/components/DroppableColumn.tsx
+++ b/packages/frontend/src/components/DroppableColumn.tsx
@@ -26,7 +26,7 @@ export function DroppableColumn({
     <div
       ref={setNodeRef}
       className={cn(
-        "rounded-lg p-3 min-h-[200px] transition-colors border-2",
+        "rounded-lg p-3 min-h-[80px] sm:min-h-[200px] transition-colors border-2",
         !isActive && "bg-gray-100/50 border-transparent",
         isActive && !isValidDrop && "bg-gray-100/50 border-transparent",
         isActive && isValidDrop && !isOver && "bg-green-50 border-transparent",

--- a/packages/frontend/src/components/KanbanBoard.tsx
+++ b/packages/frontend/src/components/KanbanBoard.tsx
@@ -89,7 +89,7 @@ export function KanbanBoard({ tasks, onTaskUpdate }: KanbanBoardProps) {
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
     >
-      <div className="grid grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         {COLUMNS.map((column) => (
           <DroppableColumn
             key={column.status}

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -1,9 +1,11 @@
-import { FolderKanban, GitFork, Github, LayoutDashboard } from "lucide-react";
+import { FolderKanban, GitFork, Github, Menu, X } from "lucide-react";
+import { useState } from "react";
 import { Link, Outlet, useLocation } from "react-router-dom";
 import { cn } from "../lib/utils";
 
 export function Layout() {
   const location = useLocation();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const navItems = [
     { to: "/projects", label: "Projects", icon: FolderKanban },
@@ -14,11 +16,25 @@ export function Layout() {
     <div className="min-h-screen bg-gray-50">
       <header className="sticky top-0 z-50 w-full border-b border-gray-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
         <div className="container mx-auto flex h-14 items-center px-4">
-          <Link to="/" className="flex items-center gap-2 font-bold text-lg">
-            <LayoutDashboard className="h-5 w-5" />
+          {/* Mobile menu button */}
+          <button
+            type="button"
+            className="md:hidden flex items-center justify-center rounded-md p-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 min-h-[44px] min-w-[44px] mr-2"
+            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={mobileMenuOpen}
+          >
+            {mobileMenuOpen ? (
+              <X className="h-6 w-6" />
+            ) : (
+              <Menu className="h-6 w-6" />
+            )}
+          </button>
+          <Link to="/" className="font-bold text-lg">
             Sahai
           </Link>
-          <nav className="ml-8 flex items-center gap-1">
+          {/* Desktop navigation */}
+          <nav className="ml-8 hidden md:flex items-center gap-1">
             {navItems.map((item) => {
               const isActive = location.pathname.startsWith(item.to);
               return (
@@ -48,6 +64,28 @@ export function Layout() {
             </a>
           </div>
         </div>
+        {/* Mobile navigation menu */}
+        {mobileMenuOpen && (
+          <nav className="md:hidden border-t border-gray-200 bg-white px-4 py-2">
+            {navItems.map((item) => {
+              const isActive = location.pathname.startsWith(item.to);
+              return (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  onClick={() => setMobileMenuOpen(false)}
+                  className={cn(
+                    "flex items-center gap-2 rounded-md px-3 py-3 text-sm font-medium transition-colors hover:bg-gray-100 hover:text-gray-900 min-h-[44px]",
+                    isActive ? "bg-gray-100 text-gray-900" : "text-gray-500",
+                  )}
+                >
+                  <item.icon className="h-4 w-4" />
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+        )}
       </header>
       <main className="container mx-auto px-4 py-6">
         <Outlet />

--- a/packages/frontend/src/pages/RepositoryDetail.tsx
+++ b/packages/frontend/src/pages/RepositoryDetail.tsx
@@ -288,20 +288,20 @@ function RepositoryDetailContent({ repositoryId }: { repositoryId: string }) {
           </Link>
         </Button>
 
-        <div className="flex items-start justify-between">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">
+            <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">
               {repository.name}
             </h1>
-            <div className="flex items-center gap-4 mt-2 text-sm text-gray-500">
-              <span className="font-mono">{repository.path}</span>
+            <div className="flex flex-wrap items-center gap-2 sm:gap-4 mt-2 text-sm text-gray-500">
+              <span className="font-mono break-all">{repository.path}</span>
               <span className="flex items-center gap-1">
                 <GitBranch className="h-4 w-4" />
                 {repository.defaultBranch}
               </span>
             </div>
           </div>
-          <div className="flex gap-2">
+          <div className="flex gap-2 shrink-0">
             <Dialog
               open={editOpen}
               onOpenChange={(open) => {


### PR DESCRIPTION
## Summary
- Make Kanban board responsive (1 column on mobile, 2 columns on tablet, 4 columns on desktop)
- Add hamburger menu for mobile navigation (left side)
- Make repository detail page responsive with stacked layout on mobile
- Reduce Kanban column min-height on mobile for better scrolling experience

## Changes
- **KanbanBoard.tsx**: Responsive grid layout (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-4`)
- **Layout.tsx**: Mobile hamburger menu with touch-friendly tap targets (44px)
- **DroppableColumn.tsx**: Smaller min-height on mobile (`min-h-[80px] sm:min-h-[200px]`)
- **RepositoryDetail.tsx**: Stacked layout for title/buttons on mobile, responsive text sizing

## Test plan
- [ ] Verify Kanban board shows 1 column on mobile (< 640px)
- [ ] Verify Kanban board shows 2 columns on tablet (640px - 1024px)
- [ ] Verify Kanban board shows 4 columns on desktop (> 1024px)
- [ ] Verify hamburger menu works on mobile
- [ ] Verify Edit/Delete buttons are visible on mobile
- [ ] Verify no horizontal scrolling on mobile devices

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)