### PR TITLE
feat: add host binding option to CLI and server

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -59,9 +59,11 @@ if (staticDir) {
 }
 
 const port = Number.parseInt(process.env.API_PORT || "49382", 10);
+const hostname = process.env.HOST || "localhost";
 
 export const server = Bun.serve({
   port,
+  hostname,
   fetch: app.fetch,
 });
 

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     port: Number(process.env.PORT) || 49381,
+    host: process.env.HOST || "localhost",
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Add `--host/-H` CLI option to specify which host/interface to bind the server to
- Support `HOST` environment variable in backend and frontend servers
- Fix default port typo in CLI (49831 -> 49381)

This enables access from other devices on the network by using `sahai -H 0.0.0.0`.

## Test plan
- [ ] Run `sahai -h` and verify new `--host` option is documented
- [ ] Run `sahai` and verify it starts on localhost by default
- [ ] Run `sahai -H 0.0.0.0` and verify it binds to all interfaces
- [ ] Verify `HOST` environment variable is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)