### PR TITLE
refactor: consolidate SSE implementations with shared utilities

### DIFF
--- a/packages/backend/src/lib/sse.ts
+++ b/packages/backend/src/lib/sse.ts
@@ -1,0 +1,181 @@
+import type { Context } from "hono";
+import { type SSEStreamingApi, streamSSE } from "hono/streaming";
+
+/**
+ * Generic EventBus for pub/sub pattern
+ * Creates subscribe/broadcast functions for a specific key type
+ */
+export function createEventBus<T>() {
+  const subscribers = new Map<string, Set<(event: T) => void>>();
+
+  function subscribe(key: string, callback: (event: T) => void): () => void {
+    if (!subscribers.has(key)) {
+      subscribers.set(key, new Set());
+    }
+    subscribers.get(key)?.add(callback);
+
+    // Return unsubscribe function
+    return () => {
+      const keySubscribers = subscribers.get(key);
+      if (keySubscribers) {
+        keySubscribers.delete(callback);
+        if (keySubscribers.size === 0) {
+          subscribers.delete(key);
+        }
+      }
+    };
+  }
+
+  function broadcast(key: string, event: T): void {
+    const keySubscribers = subscribers.get(key);
+    if (keySubscribers) {
+      for (const callback of keySubscribers) {
+        callback(event);
+      }
+    }
+  }
+
+  return { subscribe, broadcast };
+}
+
+/**
+ * Options for SSE stream handler
+ */
+interface SSEStreamOptions<T> {
+  /** Key to subscribe to (e.g., taskId, repositoryId) */
+  subscriptionKey: string;
+  /** Subscribe function from EventBus */
+  subscribe: (key: string, callback: (event: T) => void) => () => void;
+  /** Get event type from the event data */
+  getEventType: (event: T) => string;
+  /** Initial connection data to send */
+  connectedData: Record<string, unknown>;
+  /** Heartbeat interval in milliseconds (default: 30000) */
+  heartbeatInterval?: number;
+}
+
+/**
+ * Create an SSE stream handler with common patterns:
+ * - Subscribe to events
+ * - Send connected event
+ * - Periodic heartbeat
+ * - Cleanup on disconnect
+ */
+export function createSSEStream<T>(
+  c: Context,
+  options: SSEStreamOptions<T>,
+): Response {
+  const {
+    subscriptionKey,
+    subscribe,
+    getEventType,
+    connectedData,
+    heartbeatInterval = 30000,
+  } = options;
+
+  return streamSSE(c, async (stream: SSEStreamingApi) => {
+    let eventId = 0;
+
+    const unsubscribe = subscribe(subscriptionKey, (event: T) => {
+      stream.writeSSE({
+        data: JSON.stringify(event),
+        event: getEventType(event),
+        id: String(eventId++),
+      });
+    });
+
+    // Send initial connection event
+    await stream.writeSSE({
+      data: JSON.stringify({ ...connectedData, status: "connected" }),
+      event: "connected",
+      id: String(eventId++),
+    });
+
+    // Keep connection alive with periodic heartbeats
+    const heartbeat = setInterval(() => {
+      stream.writeSSE({
+        data: "",
+        event: "heartbeat",
+        id: String(eventId++),
+      });
+    }, heartbeatInterval);
+
+    // Clean up on disconnect
+    stream.onAbort(() => {
+      clearInterval(heartbeat);
+      unsubscribe();
+    });
+
+    // Keep the stream open
+    await new Promise(() => {});
+  });
+}
+
+/**
+ * Simplified SSE stream for single event type (e.g., logs)
+ */
+interface SimpleSSEStreamOptions<T> {
+  /** Key to subscribe to */
+  subscriptionKey: string;
+  /** Subscribe function from EventBus */
+  subscribe: (key: string, callback: (event: T) => void) => () => void;
+  /** Event type name */
+  eventType: string;
+  /** Initial connection data to send */
+  connectedData: Record<string, unknown>;
+  /** Heartbeat interval in milliseconds (default: 30000) */
+  heartbeatInterval?: number;
+}
+
+/**
+ * Create an SSE stream handler for single event type
+ */
+export function createSimpleSSEStream<T>(
+  c: Context,
+  options: SimpleSSEStreamOptions<T>,
+): Response {
+  const {
+    subscriptionKey,
+    subscribe,
+    eventType,
+    connectedData,
+    heartbeatInterval = 30000,
+  } = options;
+
+  return streamSSE(c, async (stream: SSEStreamingApi) => {
+    let eventId = 0;
+
+    const unsubscribe = subscribe(subscriptionKey, (event: T) => {
+      stream.writeSSE({
+        data: JSON.stringify(event),
+        event: eventType,
+        id: String(eventId++),
+      });
+    });
+
+    // Send initial connection event
+    await stream.writeSSE({
+      data: JSON.stringify({ ...connectedData, status: "connected" }),
+      event: "connected",
+      id: String(eventId++),
+    });
+
+    // Keep connection alive with periodic heartbeats
+    const heartbeat = setInterval(() => {
+      stream.writeSSE({
+        data: "",
+        event: "heartbeat",
+        id: String(eventId++),
+      });
+    }, heartbeatInterval);
+
+    // Clean up on disconnect
+    stream.onAbort(() => {
+      clearInterval(heartbeat);
+      unsubscribe();
+    });
+
+    // Keep the stream open
+    await new Promise(() => {});
+  });
+}

--- a/packages/frontend/src/hooks/index.ts
+++ b/packages/frontend/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from "./useEventSource";
 export * from "./useProjects";
 export * from "./useRepositories";
 export * from "./useTasks";

--- a/packages/frontend/src/hooks/useEventSource.ts
+++ b/packages/frontend/src/hooks/useEventSource.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface EventSourceState {
+  connected: boolean;
+  error: string | null;
+}
+
+export interface UseEventSourceOptions {
+  /** URL to connect to */
+  url: string;
+  /** Whether to connect on mount (default: true) */
+  enabled?: boolean;
+}
+
+export interface EventHandler {
+  event: string;
+  handler: (data: string) => void;
+}
+
+/**
+ * Generic hook for managing EventSource connections
+ * Handles connection state, reconnection, and cleanup
+ */
+export function useEventSource(
+  options: UseEventSourceOptions,
+  eventHandlers: EventHandler[],
+) {
+  const { url, enabled = true } = options;
+  const [state, setState] = useState<EventSourceState>({
+    connected: false,
+    error: null,
+  });
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const eventHandlersRef = useRef(eventHandlers);
+
+  // Keep handlers ref updated
+  useEffect(() => {
+    eventHandlersRef.current = eventHandlers;
+  }, [eventHandlers]);
+
+  const connect = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+    }
+
+    const eventSource = new EventSource(url);
+    eventSourceRef.current = eventSource;
+
+    eventSource.addEventListener("connected", () => {
+      setState({ connected: true, error: null });
+    });
+
+    eventSource.addEventListener("heartbeat", () => {
+      // Keep-alive, no action needed
+    });
+
+    // Register all event handlers
+    for (const { event, handler } of eventHandlersRef.current) {
+      eventSource.addEventListener(event, (e) => {
+        handler(e.data);
+      });
+    }
+
+    eventSource.onerror = () => {
+      setState((prev) => ({
+        ...prev,
+        connected: false,
+        error: "Connection lost. Reconnecting...",
+      }));
+      // EventSource will auto-reconnect
+    };
+  }, [url]);
+
+  const disconnect = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+      setState({ connected: false, error: null });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (enabled) {
+      connect();
+    }
+    return () => {
+      disconnect();
+    };
+  }, [enabled, connect, disconnect]);
+
+  return {
+    ...state,
+    reconnect: connect,
+    disconnect,
+  };
+}

--- a/packages/frontend/src/hooks/useTasks.ts
+++ b/packages/frontend/src/hooks/useTasks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type ExecutionLog,
   ExecutionLogArray,
@@ -18,6 +18,7 @@ import {
   parseTaskEvent,
   type TaskEvent,
 } from "../api";
+import { type EventHandler, useEventSource } from "./useEventSource";
 
 export function useTask(taskId: string) {
   const { data, mutate } = useSWR(`/tasks/${taskId}`, fetcher, {
@@ -41,71 +42,37 @@ export function useTaskLogs(taskId: string) {
 
 export function useTaskLogsStream(taskId: string, onStatusChange?: () => void) {
   const [logs, setLogs] = useState<ExecutionLog[]>([]);
-  const [connected, setConnected] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const eventSourceRef = useRef<EventSource | null>(null);
   const onStatusChangeRef = useRef(onStatusChange);
 
-  // Keep the ref updated
   useEffect(() => {
     onStatusChangeRef.current = onStatusChange;
   }, [onStatusChange]);
 
-  const connect = useCallback(() => {
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-    }
+  const handleLog = useCallback((data: string) => {
+    const log = parseLogEvent(data);
+    if (log) {
+      setLogs((prev) => [log, ...prev]);
 
-    const url = getTaskLogsStreamUrl(taskId);
-    const eventSource = new EventSource(url);
-    eventSourceRef.current = eventSource;
-
-    eventSource.addEventListener("connected", () => {
-      setConnected(true);
-      setError(null);
-    });
-
-    eventSource.addEventListener("log", (event) => {
-      const log = parseLogEvent(event.data);
-      if (log) {
-        setLogs((prev) => [log, ...prev]);
-
-        // Detect status change from system logs
-        if (
-          log.logType === "system" &&
-          (log.content.includes("Task moved to") ||
-            log.content.includes("task completed"))
-        ) {
-          onStatusChangeRef.current?.();
-        }
+      // Detect status change from system logs
+      if (
+        log.logType === "system" &&
+        (log.content.includes("Task moved to") ||
+          log.content.includes("task completed"))
+      ) {
+        onStatusChangeRef.current?.();
       }
-    });
-
-    eventSource.addEventListener("heartbeat", () => {
-      // Keep-alive, no action needed
-    });
-
-    eventSource.onerror = () => {
-      setConnected(false);
-      setError("Connection lost. Reconnecting...");
-      // EventSource will auto-reconnect
-    };
-  }, [taskId]);
-
-  const disconnect = useCallback(() => {
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-      eventSourceRef.current = null;
-      setConnected(false);
     }
   }, []);
 
-  useEffect(() => {
-    connect();
-    return () => {
-      disconnect();
-    };
-  }, [connect, disconnect]);
+  const eventHandlers: EventHandler[] = useMemo(
+    () => [{ event: "log", handler: handleLog }],
+    [handleLog],
+  );
+
+  const { connected, error, reconnect } = useEventSource(
+    { url: getTaskLogsStreamUrl(taskId) },
+    eventHandlers,
+  );
 
   const clearLogs = useCallback(() => {
     setLogs([]);
@@ -116,7 +83,7 @@ export function useTaskLogsStream(taskId: string, onStatusChange?: () => void) {
     connected,
     error,
     clearLogs,
-    reconnect: connect,
+    reconnect,
   };
 }
 
@@ -165,81 +132,37 @@ export function useRepositoryTasksStream(
   repositoryId: string,
   onEvent?: (event: TaskEvent) => void,
 ) {
-  const [connected, setConnected] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const eventSourceRef = useRef<EventSource | null>(null);
   const onEventRef = useRef(onEvent);
 
-  // Keep the ref updated
   useEffect(() => {
     onEventRef.current = onEvent;
   }, [onEvent]);
 
-  const connect = useCallback(() => {
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-    }
-
-    const url = getRepositoryTasksStreamUrl(repositoryId);
-    const eventSource = new EventSource(url);
-    eventSourceRef.current = eventSource;
-
-    eventSource.addEventListener("connected", () => {
-      setConnected(true);
-      setError(null);
-    });
-
-    eventSource.addEventListener("task-status-changed", (event) => {
-      const taskEvent = parseTaskEvent(event.data);
-      if (taskEvent) {
-        onEventRef.current?.(taskEvent);
-      }
-    });
-
-    eventSource.addEventListener("task-created", (event) => {
-      const taskEvent = parseTaskEvent(event.data);
-      if (taskEvent) {
-        onEventRef.current?.(taskEvent);
-      }
-    });
-
-    eventSource.addEventListener("task-deleted", (event) => {
-      const taskEvent = parseTaskEvent(event.data);
-      if (taskEvent) {
-        onEventRef.current?.(taskEvent);
-      }
-    });
-
-    eventSource.addEventListener("heartbeat", () => {
-      // Keep-alive, no action needed
-    });
-
-    eventSource.onerror = () => {
-      setConnected(false);
-      setError("Connection lost. Reconnecting...");
-      // EventSource will auto-reconnect
-    };
-  }, [repositoryId]);
-
-  const disconnect = useCallback(() => {
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-      eventSourceRef.current = null;
-      setConnected(false);
+  const handleTaskEvent = useCallback((data: string) => {
+    const taskEvent = parseTaskEvent(data);
+    if (taskEvent) {
+      onEventRef.current?.(taskEvent);
     }
   }, []);
 
-  useEffect(() => {
-    connect();
-    return () => {
-      disconnect();
-    };
-  }, [connect, disconnect]);
+  const eventHandlers: EventHandler[] = useMemo(
+    () => [
+      { event: "task-status-changed", handler: handleTaskEvent },
+      { event: "task-created", handler: handleTaskEvent },
+      { event: "task-deleted", handler: handleTaskEvent },
+    ],
+    [handleTaskEvent],
+  );
+
+  const { connected, error, reconnect } = useEventSource(
+    { url: getRepositoryTasksStreamUrl(repositoryId) },
+    eventHandlers,
+  );
 
   return {
     connected,
     error,
-    reconnect: connect,
+    reconnect,
   };
 }
 
@@ -273,81 +196,50 @@ export function useTaskMessagesStream(
   onEvent?: (event: MessageEvent) => void,
 ) {
   const [messages, setMessages] = useState<TaskMessage[]>([]);
-  const [connected, setConnected] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const eventSourceRef = useRef<EventSource | null>(null);
   const onEventRef = useRef(onEvent);
 
-  // Keep the ref updated
   useEffect(() => {
     onEventRef.current = onEvent;
   }, [onEvent]);
 
-  const connect = useCallback(() => {
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-    }
-
-    const url = getTaskMessagesStreamUrl(taskId);
-    const eventSource = new EventSource(url);
-    eventSourceRef.current = eventSource;
-
-    eventSource.addEventListener("connected", () => {
-      setConnected(true);
-      setError(null);
-    });
-
-    eventSource.addEventListener("message-queued", (event) => {
-      const messageEvent = parseMessageEvent(event.data);
-      if (messageEvent && messageEvent.type === "message-queued") {
-        setMessages((prev) => [...prev, messageEvent.message]);
-        onEventRef.current?.(messageEvent);
-      }
-    });
-
-    eventSource.addEventListener("message-delivered", (event) => {
-      const messageEvent = parseMessageEvent(event.data);
-      if (messageEvent && messageEvent.type === "message-delivered") {
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === messageEvent.messageId
-              ? {
-                  ...m,
-                  status: "delivered" as const,
-                  deliveredAt: new Date(messageEvent.deliveredAt),
-                }
-              : m,
-          ),
-        );
-        onEventRef.current?.(messageEvent);
-      }
-    });
-
-    eventSource.addEventListener("heartbeat", () => {
-      // Keep-alive, no action needed
-    });
-
-    eventSource.onerror = () => {
-      setConnected(false);
-      setError("Connection lost. Reconnecting...");
-      // EventSource will auto-reconnect
-    };
-  }, [taskId]);
-
-  const disconnect = useCallback(() => {
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-      eventSourceRef.current = null;
-      setConnected(false);
+  const handleMessageQueued = useCallback((data: string) => {
+    const messageEvent = parseMessageEvent(data);
+    if (messageEvent && messageEvent.type === "message-queued") {
+      setMessages((prev) => [...prev, messageEvent.message]);
+      onEventRef.current?.(messageEvent);
     }
   }, []);
 
-  useEffect(() => {
-    connect();
-    return () => {
-      disconnect();
-    };
-  }, [connect, disconnect]);
+  const handleMessageDelivered = useCallback((data: string) => {
+    const messageEvent = parseMessageEvent(data);
+    if (messageEvent && messageEvent.type === "message-delivered") {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === messageEvent.messageId
+            ? {
+                ...m,
+                status: "delivered" as const,
+                deliveredAt: new Date(messageEvent.deliveredAt),
+              }
+            : m,
+        ),
+      );
+      onEventRef.current?.(messageEvent);
+    }
+  }, []);
+
+  const eventHandlers: EventHandler[] = useMemo(
+    () => [
+      { event: "message-queued", handler: handleMessageQueued },
+      { event: "message-delivered", handler: handleMessageDelivered },
+    ],
+    [handleMessageQueued, handleMessageDelivered],
+  );
+
+  const { connected, error, reconnect } = useEventSource(
+    { url: getTaskMessagesStreamUrl(taskId) },
+    eventHandlers,
+  );
 
   const clearMessages = useCallback(() => {
     setMessages([]);
@@ -358,7 +250,7 @@ export function useTaskMessagesStream(
     connected,
     error,
     clearMessages,
-    reconnect: connect,
+    reconnect,
   };
 }
 


### PR DESCRIPTION
## Summary

- Add backend SSE utility (`lib/sse.ts`) with `createEventBus` and `createSSEStream` helpers
- Replace 3 duplicate subscribe/broadcast implementations with shared EventBus
- Simplify SSE endpoints from ~30 lines each to ~5 lines
- Add frontend `useEventSource` hook for shared EventSource connection management
- Refactor `useTaskLogsStream`, `useRepositoryTasksStream`, `useTaskMessagesStream` to use shared hook
- Remove duplicate SSE code from `TaskDetail.tsx` ChatInput component

### Before/After Comparison

| Item | Before | After |
|------|--------|-------|
| Backend subscribe/broadcast | 3 sets × ~50 lines | 1 shared utility |
| Backend SSE endpoints | ~30 lines each | ~5 lines each |
| Frontend SSE hooks | ~80 lines each | ~30 lines each |
| TaskDetail.tsx SSE | Direct implementation (50 lines) | Uses hook |

## Test plan

- [ ] Verify real-time log streaming works on task detail page
- [ ] Verify Kanban board updates in real-time when task status changes
- [ ] Verify message queue updates in real-time when messages are queued/delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)