### PR TITLE
fix: restrict manual task state transitions on Kanban board

### DIFF
--- a/packages/frontend/src/components/KanbanBoard.tsx
+++ b/packages/frontend/src/components/KanbanBoard.tsx
@@ -25,11 +25,15 @@ const COLUMNS: { status: Status; label: string }[] = [
   { status: "Done", label: "Done" },
 ];
 
+// Only manual transitions allowed via drag-and-drop:
+// - TODO → InProgress: User starts working on a task
+// - InReview → Done: User approves a completed task
+// All other transitions are handled automatically by the system
 const VALID_TRANSITIONS: Record<Status, Status[]> = {
   TODO: ["InProgress"],
-  InProgress: ["TODO", "InReview"],
-  InReview: ["InProgress", "Done"],
-  Done: ["InReview"],
+  InProgress: [],
+  InReview: ["Done"],
+  Done: [],
 };
 
 export function canTransition(from: Status, to: Status): boolean {


### PR DESCRIPTION
## Summary
- Restricts manual drag-and-drop transitions on the Kanban board to only valid user actions:
  - **TODO → InProgress**: User starts working on a task
  - **InReview → Done**: User approves a completed task
- All other transitions (e.g., InProgress → InReview) are now handled automatically by the system

Closes #109

## Test plan
- [ ] Verify tasks can be dragged from TODO to InProgress
- [ ] Verify tasks can be dragged from InReview to Done
- [ ] Verify other transitions show red highlight (invalid drop zone) and are rejected
- [ ] Verify InProgress and Done columns don't allow any outgoing drag-and-drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)