### PR TITLE
feat: Implement MCP Server for Task Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,34 @@ npx sahai@latest --help        # Show help
 npx sahai@latest --version     # Show version
 ```
 
+## MCP Server Integration
+
+Sahai includes an MCP (Model Context Protocol) server that allows AI agents like Claude Code to create and manage tasks programmatically.
+
+**Endpoint:** `http://localhost:49381/v1/mcp`
+
+Add to your Claude Code MCP settings (`~/.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "sahai": {
+      "type": "url",
+      "url": "http://localhost:49381/v1/mcp"
+    }
+  }
+}
+```
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `create_task` | Create a new task in a repository |
+| `start_task` | Start a task (creates worktree and spawns executor) |
+| `resume_task` | Resume a paused task with optional message |
+| `get_task` | Get details of a specific task |
+
 ## Configuration
 
 | Variable | Default | Description |

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,6 +10,7 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
     "drizzle-orm": "^0.44.7",
     "hono": "^4.6.0",
     "shared": "workspace:*"

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -5,6 +5,7 @@ import { serveStatic } from "hono/bun";
 import { cors } from "hono/cors";
 import { runMigrations } from "./db/client";
 import filesystem from "./routes/filesystem";
+import mcp from "./routes/mcp";
 import projectRepositories from "./routes/project-repositories";
 import projects from "./routes/projects";
 import repositories from "./routes/repositories";
@@ -40,6 +41,7 @@ app.route("/v1/tasks", taskById);
 app.route("/v1/filesystem", filesystem);
 app.route("/v1/settings", settings);
 app.route("/v1/sounds", sounds);
+app.route("/v1/mcp", mcp);
 
 // Serve static files in production mode
 if (staticDir) {

--- a/packages/backend/src/routes/mcp.ts
+++ b/packages/backend/src/routes/mcp.ts
@@ -1,0 +1,520 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import { Task } from "shared";
+import { db } from "../db/client";
+import { repositories, tasks } from "../db/schema";
+import {
+  resumeTaskExecution,
+  startTaskExecution,
+  withExecutingStatus,
+} from "../services/task";
+
+// Session storage for MCP
+interface McpSession {
+  id: string;
+}
+
+const sessions = new Map<string, McpSession>();
+
+// Type for task with optional isExecuting field
+type TaskWithExecuting = Task & { isExecuting?: boolean };
+
+function formatTask(task: TaskWithExecuting): string {
+  return JSON.stringify(
+    {
+      id: task.id,
+      repositoryId: task.repositoryId,
+      title: task.title,
+      description: task.description,
+      status: task.status,
+      executor: task.executor,
+      branchName: task.branchName,
+      baseBranch: task.baseBranch,
+      worktreePath: task.worktreePath,
+      isExecuting: task.isExecuting,
+      createdAt:
+        task.createdAt instanceof Date
+          ? task.createdAt.toISOString()
+          : task.createdAt,
+      updatedAt:
+        task.updatedAt instanceof Date
+          ? task.updatedAt.toISOString()
+          : task.updatedAt,
+      startedAt: task.startedAt
+        ? task.startedAt instanceof Date
+          ? task.startedAt.toISOString()
+          : task.startedAt
+        : undefined,
+      completedAt: task.completedAt
+        ? task.completedAt instanceof Date
+          ? task.completedAt.toISOString()
+          : task.completedAt
+        : undefined,
+    },
+    null,
+    2,
+  );
+}
+
+// JSON-RPC types
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: string | number | null;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+const mcp = new Hono();
+
+// Handle MCP POST requests (JSON-RPC)
+mcp.post("/", async (c) => {
+  const sessionId = c.req.header("mcp-session-id");
+  const body = await c.req.json<JsonRpcRequest | JsonRpcRequest[]>();
+
+  // Handle single request or batch
+  const requests = Array.isArray(body) ? body : [body];
+  const responses: JsonRpcResponse[] = [];
+
+  // Check for initialization request
+  const isInitRequest = requests.some((req) => req.method === "initialize");
+
+  let session: McpSession | undefined;
+
+  if (isInitRequest && !sessionId) {
+    // Create new session
+    const newSessionId = randomUUID();
+    session = { id: newSessionId };
+    sessions.set(newSessionId, session);
+
+    // Set session ID header
+    c.header("mcp-session-id", newSessionId);
+  } else if (sessionId) {
+    session = sessions.get(sessionId);
+    if (!session) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Invalid session ID" },
+          id: null,
+        },
+        404,
+      );
+    }
+  } else {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Missing session ID" },
+        id: null,
+      },
+      400,
+    );
+  }
+
+  // Process each request
+  for (const request of requests) {
+    try {
+      const response = await handleJsonRpcRequest(request);
+      if (response) {
+        responses.push(response);
+      }
+    } catch (error) {
+      responses.push({
+        jsonrpc: "2.0",
+        id: request.id ?? null,
+        error: {
+          code: -32603,
+          message: error instanceof Error ? error.message : "Internal error",
+        },
+      });
+    }
+  }
+
+  // Return responses
+  if (Array.isArray(body)) {
+    return c.json(responses);
+  }
+  return c.json(responses[0]);
+});
+
+// Handle MCP GET requests (SSE stream for server-to-client notifications)
+mcp.get("/", async (c) => {
+  const sessionId = c.req.header("mcp-session-id");
+  if (!sessionId) {
+    return c.text("Missing session ID", 400);
+  }
+
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return c.text("Invalid session ID", 404);
+  }
+
+  return streamSSE(c, async (stream) => {
+    // Send initial connected event
+    await stream.writeSSE({ event: "connected", data: "connected" });
+
+    // Keep connection alive with heartbeat
+    const heartbeat = setInterval(async () => {
+      try {
+        await stream.writeSSE({ event: "heartbeat", data: "" });
+      } catch {
+        clearInterval(heartbeat);
+      }
+    }, 30000);
+
+    // Clean up on close
+    stream.onAbort(() => {
+      clearInterval(heartbeat);
+    });
+  });
+});
+
+// Handle MCP DELETE requests (session termination)
+mcp.delete("/", async (c) => {
+  const sessionId = c.req.header("mcp-session-id");
+  if (!sessionId) {
+    return c.text("Missing session ID", 400);
+  }
+
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return c.text("Invalid session ID", 404);
+  }
+
+  sessions.delete(sessionId);
+  return c.text("Session terminated", 200);
+});
+
+async function handleJsonRpcRequest(
+  request: JsonRpcRequest,
+): Promise<JsonRpcResponse | null> {
+  const { method, params, id } = request;
+
+  // Handle MCP protocol methods
+  switch (method) {
+    case "initialize":
+      return {
+        jsonrpc: "2.0",
+        id: id ?? null,
+        result: {
+          protocolVersion: "2024-11-05",
+          capabilities: {
+            tools: {},
+          },
+          serverInfo: {
+            name: "sahai",
+            version: "0.1.0",
+          },
+        },
+      };
+
+    case "notifications/initialized":
+      // No response for notifications
+      return null;
+
+    case "tools/list":
+      return {
+        jsonrpc: "2.0",
+        id: id ?? null,
+        result: {
+          tools: [
+            {
+              name: "create_task",
+              description:
+                "Create a new task in a repository. The task will be created in TODO status.",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  repositoryId: {
+                    type: "string",
+                    description: "UUID of the target repository",
+                  },
+                  title: { type: "string", description: "Task title" },
+                  description: {
+                    type: "string",
+                    description: "Task description",
+                  },
+                  executor: {
+                    type: "string",
+                    enum: ["ClaudeCode", "Codex", "Copilot", "Gemini"],
+                    description: "AI agent to execute the task",
+                  },
+                  branchName: {
+                    type: "string",
+                    description: "Git branch name for the task",
+                  },
+                  baseBranch: {
+                    type: "string",
+                    description:
+                      "Base branch (defaults to repository's default branch)",
+                  },
+                },
+                required: ["repositoryId", "title", "executor", "branchName"],
+              },
+            },
+            {
+              name: "start_task",
+              description:
+                "Start a task that is in TODO status. Creates git worktree and spawns the executor.",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  taskId: {
+                    type: "string",
+                    description: "UUID of the task to start",
+                  },
+                },
+                required: ["taskId"],
+              },
+            },
+            {
+              name: "resume_task",
+              description:
+                "Resume a paused task (InProgress or InReview status) with an optional message.",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  taskId: {
+                    type: "string",
+                    description: "UUID of the task to resume",
+                  },
+                  message: {
+                    type: "string",
+                    description:
+                      "Additional instructions/context for the executor",
+                  },
+                },
+                required: ["taskId"],
+              },
+            },
+            {
+              name: "get_task",
+              description: "Get details of a specific task.",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  taskId: {
+                    type: "string",
+                    description: "UUID of the task to retrieve",
+                  },
+                },
+                required: ["taskId"],
+              },
+            },
+          ],
+        },
+      };
+
+    case "tools/call": {
+      const toolParams = params as {
+        name: string;
+        arguments?: Record<string, unknown>;
+      };
+      const toolName = toolParams.name;
+      const toolArgs = toolParams.arguments || {};
+
+      try {
+        const result = await executeToolCall(toolName, toolArgs);
+        return {
+          jsonrpc: "2.0",
+          id: id ?? null,
+          result,
+        };
+      } catch (error) {
+        return {
+          jsonrpc: "2.0",
+          id: id ?? null,
+          error: {
+            code: -32603,
+            message:
+              error instanceof Error ? error.message : "Tool execution failed",
+          },
+        };
+      }
+    }
+
+    default:
+      return {
+        jsonrpc: "2.0",
+        id: id ?? null,
+        error: {
+          code: -32601,
+          message: `Method not found: ${method}`,
+        },
+      };
+  }
+}
+
+async function executeToolCall(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  switch (name) {
+    case "create_task": {
+      const repositoryId = args.repositoryId as string;
+      const title = args.title as string;
+      const description = args.description as string | undefined;
+      const executor = args.executor as string;
+      const branchName = args.branchName as string;
+      const baseBranch = args.baseBranch as string | undefined;
+
+      // Validate executor
+      const validExecutors = ["ClaudeCode", "Codex", "Copilot", "Gemini"];
+      if (!validExecutors.includes(executor)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                error: "BAD_REQUEST",
+                message: `Invalid executor: ${executor}`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Get repository
+      const repo = await db
+        .select()
+        .from(repositories)
+        .where(eq(repositories.id, repositoryId));
+      if (repo.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                error: "NOT_FOUND",
+                message: "Repository not found",
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const now = new Date().toISOString();
+      const resolvedBaseBranch = baseBranch || repo[0].defaultBranch;
+
+      const newTask = {
+        id: randomUUID(),
+        repositoryId,
+        title,
+        description: description || null,
+        status: "TODO" as const,
+        executor: executor as "ClaudeCode" | "Codex" | "Copilot" | "Gemini",
+        branchName,
+        baseBranch: resolvedBaseBranch,
+        worktreePath: null,
+        createdAt: now,
+        updatedAt: now,
+        startedAt: null,
+        completedAt: null,
+      };
+
+      await db.insert(tasks).values(newTask);
+      const task = Task.parse(newTask);
+
+      return {
+        content: [{ type: "text", text: formatTask(task) }],
+      };
+    }
+
+    case "start_task": {
+      const taskId = args.taskId as string;
+      const { task, error } = await startTaskExecution(taskId);
+      if (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ error }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      return {
+        content: [{ type: "text", text: formatTask(task) }],
+      };
+    }
+
+    case "resume_task": {
+      const taskId = args.taskId as string;
+      const message = args.message as string | undefined;
+      const { task, error } = await resumeTaskExecution(taskId, message);
+      if (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ error }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      return {
+        content: [{ type: "text", text: formatTask(task) }],
+      };
+    }
+
+    case "get_task": {
+      const taskId = args.taskId as string;
+      const result = await db.select().from(tasks).where(eq(tasks.id, taskId));
+      if (result.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                error: "NOT_FOUND",
+                message: "Task not found",
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const task = Task.parse(withExecutingStatus(result[0]));
+      return {
+        content: [{ type: "text", text: formatTask(task) }],
+      };
+    }
+
+    default:
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: "NOT_FOUND",
+              message: `Unknown tool: ${name}`,
+            }),
+          },
+        ],
+        isError: true,
+      };
+  }
+}
+
+export default mcp;

--- a/packages/backend/src/services/task.ts
+++ b/packages/backend/src/services/task.ts
@@ -1,0 +1,295 @@
+import { tmpdir } from "node:os";
+import { eq } from "drizzle-orm";
+import { isExecutorEnabled } from "../config/agent";
+import { db } from "../db/client";
+import { executionLogs, repositories, tasks } from "../db/schema";
+import { ClaudeCodeExecutor } from "../executors/claude";
+import { CodexExecutor } from "../executors/codex";
+import { CopilotExecutor } from "../executors/copilot";
+import { GeminiExecutor } from "../executors/gemini";
+import type { Executor } from "../executors/interface";
+import { createBranch } from "./git";
+import { createWorktree } from "./worktree";
+
+// In-memory store for active executors
+const activeExecutors = new Map<string, Executor>();
+
+export function getActiveExecutors(): Map<string, Executor> {
+  return activeExecutors;
+}
+
+export function isExecutorActive(taskId: string): boolean {
+  return activeExecutors.has(taskId);
+}
+
+export function getExecutor(taskId: string): Executor | undefined {
+  return activeExecutors.get(taskId);
+}
+
+export function setExecutor(taskId: string, executor: Executor): void {
+  activeExecutors.set(taskId, executor);
+}
+
+export function removeExecutor(taskId: string): void {
+  activeExecutors.delete(taskId);
+}
+
+export function createExecutor(type: string): Executor {
+  switch (type) {
+    case "ClaudeCode":
+      return new ClaudeCodeExecutor();
+    case "Codex":
+      return new CodexExecutor();
+    case "Copilot":
+      return new CopilotExecutor();
+    case "Gemini":
+      return new GeminiExecutor();
+    default:
+      throw new Error(`Unsupported executor type: ${type}`);
+  }
+}
+
+// Add isExecuting field to task based on activeExecutors
+export function withExecutingStatus<T extends { id: string }>(
+  task: T,
+): T & { isExecuting: boolean } {
+  return {
+    ...task,
+    isExecuting: activeExecutors.has(task.id),
+  };
+}
+
+export interface TaskEventHandler {
+  onLog?: (log: {
+    id: string;
+    taskId: string;
+    content: string;
+    logType: string;
+    createdAt: string;
+  }) => void;
+  onStatusChange?: (event: {
+    taskId: string;
+    repositoryId: string;
+    oldStatus: string;
+    newStatus: string;
+    isExecuting: boolean;
+    updatedAt: string;
+  }) => void;
+  onExecutorExit?: (taskId: string) => void;
+}
+
+export async function startTaskExecution(
+  taskId: string,
+  eventHandler?: TaskEventHandler,
+): Promise<{ task: ReturnType<typeof withExecutingStatus>; error?: string }> {
+  const now = new Date().toISOString();
+
+  const taskResult = await db.select().from(tasks).where(eq(tasks.id, taskId));
+  if (taskResult.length === 0) {
+    return { task: null as never, error: "NOT_FOUND: Task not found" };
+  }
+
+  const task = taskResult[0];
+
+  if (task.status !== "TODO") {
+    return {
+      task: null as never,
+      error: `INVALID_STATE_TRANSITION: Cannot start task in ${task.status} status`,
+    };
+  }
+
+  // Check if the executor/agent is enabled
+  const isEnabled = await isExecutorEnabled(task.executor);
+  if (!isEnabled) {
+    return {
+      task: null as never,
+      error: `BAD_REQUEST: Agent "${task.executor}" is disabled in settings`,
+    };
+  }
+
+  // Get repository info
+  const repoResult = await db
+    .select()
+    .from(repositories)
+    .where(eq(repositories.id, task.repositoryId));
+
+  if (repoResult.length === 0) {
+    return { task: null as never, error: "NOT_FOUND: Repository not found" };
+  }
+
+  const repo = repoResult[0];
+  const worktreePath = `${tmpdir()}/sahai-worktrees/${task.id}`;
+
+  // Create branch from base branch
+  await createBranch(repo.path, task.branchName, task.baseBranch);
+
+  // Create worktree
+  await createWorktree(repo.path, worktreePath, task.branchName);
+
+  // Update task status
+  await db
+    .update(tasks)
+    .set({
+      status: "InProgress",
+      worktreePath,
+      startedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(tasks.id, taskId));
+
+  // Create and start executor
+  const executor = createExecutor(task.executor);
+
+  executor.onOutput(async (output) => {
+    const log = {
+      id: crypto.randomUUID(),
+      taskId,
+      content: output.content,
+      logType: output.logType,
+      createdAt: new Date().toISOString(),
+    };
+    await db.insert(executionLogs).values(log);
+    eventHandler?.onLog?.(log);
+  });
+
+  executor.onExit(() => {
+    eventHandler?.onExecutorExit?.(taskId);
+  });
+
+  executor.onSessionId(async (sessionId) => {
+    console.log(
+      `[task-service] Saving session ID ${sessionId} for task ${taskId}`,
+    );
+    await db
+      .update(tasks)
+      .set({ sessionId, updatedAt: new Date().toISOString() })
+      .where(eq(tasks.id, taskId));
+  });
+
+  await executor.start({
+    taskId,
+    workingDirectory: worktreePath,
+    prompt: task.description ?? task.title,
+  });
+
+  activeExecutors.set(taskId, executor);
+
+  // Notify status change
+  eventHandler?.onStatusChange?.({
+    taskId,
+    repositoryId: task.repositoryId,
+    oldStatus: "TODO",
+    newStatus: "InProgress",
+    isExecuting: true,
+    updatedAt: now,
+  });
+
+  const updatedTask = await db.select().from(tasks).where(eq(tasks.id, taskId));
+  return { task: withExecutingStatus(updatedTask[0]) };
+}
+
+export async function resumeTaskExecution(
+  taskId: string,
+  message?: string,
+  eventHandler?: TaskEventHandler,
+): Promise<{ task: ReturnType<typeof withExecutingStatus>; error?: string }> {
+  const now = new Date().toISOString();
+
+  const taskResult = await db.select().from(tasks).where(eq(tasks.id, taskId));
+  if (taskResult.length === 0) {
+    return { task: null as never, error: "NOT_FOUND: Task not found" };
+  }
+
+  const task = taskResult[0];
+
+  if (task.status !== "InProgress" && task.status !== "InReview") {
+    return {
+      task: null as never,
+      error: `INVALID_STATE_TRANSITION: Cannot resume task in ${task.status} status`,
+    };
+  }
+
+  if (!task.worktreePath) {
+    return { task: null as never, error: "BAD_REQUEST: Task has no worktree" };
+  }
+
+  // Check if the executor/agent is enabled
+  const isEnabled = await isExecutorEnabled(task.executor);
+  if (!isEnabled) {
+    return {
+      task: null as never,
+      error: `BAD_REQUEST: Agent "${task.executor}" is disabled in settings`,
+    };
+  }
+
+  // Stop existing executor if running
+  const existingExecutor = activeExecutors.get(taskId);
+  if (existingExecutor) {
+    await existingExecutor.stop();
+    activeExecutors.delete(taskId);
+  }
+
+  // Create and start executor
+  const executor = createExecutor(task.executor);
+
+  executor.onOutput(async (output) => {
+    const log = {
+      id: crypto.randomUUID(),
+      taskId,
+      content: output.content,
+      logType: output.logType,
+      createdAt: new Date().toISOString(),
+    };
+    await db.insert(executionLogs).values(log);
+    eventHandler?.onLog?.(log);
+  });
+
+  executor.onExit(() => {
+    eventHandler?.onExecutorExit?.(taskId);
+  });
+
+  executor.onSessionId(async (sessionId) => {
+    console.log(
+      `[task-service] Saving session ID ${sessionId} for task ${taskId}`,
+    );
+    await db
+      .update(tasks)
+      .set({ sessionId, updatedAt: new Date().toISOString() })
+      .where(eq(tasks.id, taskId));
+  });
+
+  const prompt = message ?? task.description ?? task.title;
+
+  await executor.start({
+    taskId,
+    workingDirectory: task.worktreePath,
+    prompt,
+    sessionId: task.sessionId ?? undefined,
+  });
+
+  activeExecutors.set(taskId, executor);
+
+  // Update status to InProgress if it was InReview
+  if (task.status === "InReview") {
+    await db
+      .update(tasks)
+      .set({
+        status: "InProgress",
+        updatedAt: now,
+      })
+      .where(eq(tasks.id, taskId));
+
+    // Notify status change
+    eventHandler?.onStatusChange?.({
+      taskId,
+      repositoryId: task.repositoryId,
+      oldStatus: "InReview",
+      newStatus: "InProgress",
+      isExecuting: true,
+      updatedAt: now,
+    });
+  }
+
+  const updatedTask = await db.select().from(tasks).where(eq(tasks.id, taskId));
+  return { task: withExecutingStatus(updatedTask[0]) };
+}


### PR DESCRIPTION
## Summary

- Implement MCP (Model Context Protocol) Server to expose sahai's task management capabilities as tools for AI agents like Claude Code
- MCP server is integrated into the backend and starts automatically with sahai
- Also provides standalone stdio transport option for direct Claude Code integration

## Changes

### Integrated HTTP Transport
- Add MCP routes at `/v1/mcp` with JSON-RPC over HTTP
- Support POST (requests), GET (SSE stream), DELETE (session termination)

### MCP Tools
| Tool | Description |
|------|-------------|
| `create_task` | Create a new task in a repository (status: TODO) |
| `start_task` | Start a TODO task (creates worktree, spawns executor) |
| `resume_task` | Resume a paused task with optional message |
| `get_task` | Get full task details |

### Refactored Task Functions
- Export `startTask()`, `resumeTask()`, `withExecutingStatus()` from tasks.ts
- Enable code reuse between REST API routes and MCP handlers

### Standalone Package
- Add `packages/mcp-server/` for stdio transport option

## Claude Code Configuration

```json
{
  "mcpServers": {
    "sahai": {
      "type": "url",
      "url": "http://localhost:49381/v1/mcp"
    }
  }
}
```

## Test plan

- [ ] Run `bun run dev` and verify MCP endpoint is displayed in startup message
- [ ] Test MCP protocol with Claude Code or manual JSON-RPC requests
- [ ] Verify `create_task`, `start_task`, `resume_task`, `get_task` tools work correctly

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)