### PR TITLE
feat: add desktop notification when task completes

### DIFF
--- a/packages/backend/src/lib/notification.ts
+++ b/packages/backend/src/lib/notification.ts
@@ -1,0 +1,54 @@
+/**
+ * Cross-platform desktop notification utility
+ * Uses osascript on macOS and notify-send on Linux
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+/**
+ * Show a desktop notification
+ * @param title - Notification title
+ * @param message - Notification body message
+ */
+export async function showDesktopNotification(
+  title: string,
+  message: string,
+): Promise<void> {
+  try {
+    const platform = process.platform;
+
+    if (platform === "darwin") {
+      // macOS: use osascript
+      const escapedTitle = title.replace(/"/g, '\\"');
+      const escapedMessage = message.replace(/"/g, '\\"');
+      await execAsync(
+        `osascript -e 'display notification "${escapedMessage}" with title "${escapedTitle}"'`,
+      );
+    } else if (platform === "linux") {
+      // Linux: use notify-send
+      const escapedTitle = title.replace(/'/g, "'\\''");
+      const escapedMessage = message.replace(/'/g, "'\\''");
+      await execAsync(`notify-send '${escapedTitle}' '${escapedMessage}'`);
+    }
+    // Windows and other platforms: silently skip
+  } catch (error) {
+    // Silently ignore errors - notification is not critical
+    console.error("Failed to show desktop notification:", error);
+  }
+}
+
+/**
+ * Show task completion notification
+ * @param taskTitle - Title of the completed task
+ */
+export async function showTaskCompletedNotification(
+  taskTitle: string,
+): Promise<void> {
+  await showDesktopNotification(
+    "Task Completed",
+    `"${taskTitle}" moved to In Review`,
+  );
+}

--- a/packages/backend/src/services/task.ts
+++ b/packages/backend/src/services/task.ts
@@ -14,6 +14,7 @@ import { CodexExecutor } from "../executors/codex";
 import { CopilotExecutor } from "../executors/copilot";
 import { GeminiExecutor } from "../executors/gemini";
 import type { Executor } from "../executors/interface";
+import { showTaskCompletedNotification } from "../lib/notification";
 import { playSuccessSound } from "../lib/sound";
 import { createBranch, deleteBranch } from "./git";
 import { copyFilesToWorktree, runLifecycleScript } from "./lifecycle";
@@ -300,6 +301,7 @@ async function transitionToInReviewInternal(
   });
 
   playSuccessSound();
+  showTaskCompletedNotification(task?.title ?? "Task");
   console.log(`[task-service] Transition to InReview complete`);
 }
 


### PR DESCRIPTION
## Summary
- Add native desktop notifications when a task completes (moves to InReview status)
- Uses `osascript` on macOS and `notify-send` on Linux
- Notifications show task title

Closes #140

## Test plan
- [ ] Start a task and wait for it to complete
- [ ] Verify desktop notification appears with task title
- [ ] Test on macOS with osascript
- [ ] Test on Linux with notify-send (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)